### PR TITLE
Fix fit-width ignoring sidebar and scrollbar widths

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -849,7 +849,7 @@ async function fitWidth() {
   const vp = await v.getViewport(1);
   const tocW       = tocPanel.classList.contains('hidden') ? 0 : tocPanel.offsetWidth;
   const sbRight    = tocW + SCROLLBAR_GAP + 10; // scrollbar sits left of toc (10px wide) with gap
-  const availableW = activeTab.pane.clientWidth - sidebar.offsetWidth - sbRight;
+  const availableW = activeTab.pane.clientWidth - 2 * Math.max(sidebar.offsetWidth, sbRight);
   await _applyZoomNow(Math.round(((availableW - 32) / (vp.width / v.scale)) * 100) / 100);
 }
 


### PR DESCRIPTION
## Summary
- `fitWidth` was using `pane.clientWidth` as the available width, but the viewer pane fills the full window (`inset: 0`) with the left sidebar, right TOC panel, and custom scrollbar overlaid on top
- Now subtracts the left sidebar width, TOC panel width (when visible), and the custom scrollbar space (`SCROLLBAR_GAP + 10px`) before computing the scale

Closes #23