### PR TITLE
Hotfix: include native messaging host in installer (v0.2.3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Compile TypeScript
         run: pnpm run build
 
+      - name: Build native messaging host
+        run: pnpm run build-native-host
+
       - name: Package Windows installer + portable
         run: pnpm exec electron-builder --win nsis portable --x64 --publish never
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reamlet",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Lightweight standalone PDF viewer for Windows",
   "main": "out/main.js",
   "packageManager": "pnpm@10.32.1",


### PR DESCRIPTION
## Summary

- Fixes `reamlet-native-host.exe` missing from the Windows installer in v0.2.2
- Bumps version to 0.2.3

## Root cause

The release CI workflow ran `build` then went straight to electron-builder, skipping `build-native-host`. This meant `native-host/dist/reamlet-native-host.exe` didn't exist at packaging time, so electron-builder silently omitted it from the installer bundle.

The local `build-win` script already ran `build-native-host` correctly — this was CI-only.

## Fix

Added `pnpm run build-native-host` as an explicit step in the Windows build job, between TypeScript compilation and electron-builder packaging.

## Impact

Users who installed v0.2.2 will have `reamlet-native-host.exe` missing and the browser extension will fail to connect. They need to reinstall with v0.2.3. The setup flow (install → enter Extension ID → restart browser) is unchanged.