### PR TITLE
Move extension-staged downloads to temp, add hourly cleanup

### DIFF
--- a/native-host/host.js
+++ b/native-host/host.js
@@ -113,15 +113,34 @@ function moveToTemp(filePath) {
 // ── Message handler ───────────────────────────────────────────
 
 function handleMessage(msg) {
-  const { url, background } = msg;
-  if (!url || typeof url !== 'string') {
-    reply({ ok: false, error: 'missing url' });
-    return;
-  }
+  const { url, bytes, background } = msg;
 
   const { found: reamletPath, checked } = findReamlet();
   if (!reamletPath) {
     reply({ ok: false, error: 'Reamlet.exe not found', checked });
+    return;
+  }
+
+  // bytes message: extension fetched the PDF directly and sent the raw bytes
+  // as base64 (used when chrome.downloads fails with SERVER_BAD_CONTENT).
+  if (bytes) {
+    try {
+      const tempDir = path.join(os.tmpdir(), 'ReamletDownloads');
+      fs.mkdirSync(tempDir, { recursive: true });
+      const tempPath = path.join(tempDir, `${Date.now()}.pdf`);
+      fs.writeFileSync(tempPath, Buffer.from(bytes, 'base64'));
+      const args = background ? [tempPath, '--background'] : [tempPath];
+      const child = spawn(reamletPath, args, { detached: true, stdio: 'ignore' });
+      child.unref();
+      reply({ ok: true });
+    } catch (err) {
+      reply({ ok: false, error: err.message });
+    }
+    return;
+  }
+
+  if (!url || typeof url !== 'string') {
+    reply({ ok: false, error: 'missing url or bytes' });
     return;
   }
 

--- a/native-host/host.js
+++ b/native-host/host.js
@@ -87,6 +87,29 @@ function findReamlet() {
   return { found: null, checked: candidates };
 }
 
+// ── Helpers ───────────────────────────────────────────────────
+
+const os = require('os');
+
+function isLocalPath(s) {
+  // Windows absolute paths: C:\... or UNC paths \\...
+  return /^[A-Za-z]:\\/.test(s) || s.startsWith('\\\\');
+}
+
+// Move a file into %TEMP%\ReamletDownloads, returning the new path.
+// Falls back to the original path on any error.
+function moveToTemp(filePath) {
+  try {
+    const tempDir = path.join(os.tmpdir(), 'ReamletDownloads');
+    fs.mkdirSync(tempDir, { recursive: true });
+    const dest = path.join(tempDir, path.basename(filePath));
+    fs.renameSync(filePath, dest);
+    return dest;
+  } catch {
+    return filePath;
+  }
+}
+
 // ── Message handler ───────────────────────────────────────────
 
 function handleMessage(msg) {
@@ -102,7 +125,11 @@ function handleMessage(msg) {
     return;
   }
 
-  const args = background ? [url, '--background'] : [url];
+  // If the extension staged a local file, move it into the shared temp folder
+  // so Reamlet's periodic cleanup can manage it alongside URL-based downloads.
+  const target = isLocalPath(url) ? moveToTemp(url) : url;
+
+  const args = background ? [target, '--background'] : [target];
   const child = spawn(reamletPath, args, {
     detached: true,
     stdio: 'ignore',

--- a/src/main.ts
+++ b/src/main.ts
@@ -298,6 +298,24 @@ function getArgvTarget(argv: string[]): string | null {
   return null;
 }
 
+// Delete files in %TEMP%\ReamletDownloads that are older than 24 hours.
+function _cleanupTempDownloads() {
+  const tempDir = path.join(os.tmpdir(), 'ReamletDownloads');
+  const oneDayMs = 24 * 60 * 60 * 1000;
+  try {
+    const now = Date.now();
+    for (const file of fs.readdirSync(tempDir)) {
+      const filePath = path.join(tempDir, file);
+      try {
+        if (now - fs.statSync(filePath).mtimeMs > oneDayMs) fs.unlinkSync(filePath);
+      } catch { /* file in use or already gone */ }
+    }
+  } catch { /* dir doesn't exist yet */ }
+}
+
+_cleanupTempDownloads();
+setInterval(_cleanupTempDownloads, 60 * 60 * 1000);
+
 // Download a remote PDF to %TEMP%\ReamletDownloads and return the local path.
 // Follows up to 5 redirects. Rejects on HTTP errors or network failures.
 function downloadPdfToTemp(url: string, redirectsLeft = 5): Promise<string> {


### PR DESCRIPTION
## Summary

- Native host moves locally-staged files into `%TEMP%\ReamletDownloads` before launching Reamlet
- Reamlet cleans up files in `%TEMP%\ReamletDownloads` older than 24 hours, on startup and every hour

## Detail

When the browser extension downloads a PDF (to handle authenticated URLs), it can only write to paths relative to the user's Downloads folder. It stages the file in `Downloads\Reamlet\`. The native host now detects when it receives a local file path and moves it into `%TEMP%\ReamletDownloads` before handing it to Reamlet — keeping all temp PDFs in one place regardless of how they arrived.

The extension erases the download history entry immediately after sending the path, so nothing lingers in Chrome's download bar or history.

The cleanup runs on app startup and once per hour, removing any file whose modified time is older than 24 hours. Files currently open in Reamlet are skipped gracefully if deletion fails.

## Related

Companion to Reamlet-extension PR #5 (fix/authenticated-pdf-downloads).