### PR TITLE
Fit width automatically when a PDF is first loaded

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -682,6 +682,7 @@ async function _loadTabContent(tab: Tab) {
     renderToc(tab.outline);
     updatePageDisplay(tab);
     _syncScrollbar();
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
     await fitWidth();
   }
 }

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -530,6 +530,10 @@ function switchTab(tab: Tab) {
   attachScrollListener(tab);
   _positionScrollbar();
   finder.onTabSwitch();
+  if (tab._notBeenViewed) {
+    tab._notBeenViewed = false;
+    void fitWidth();
+  }
 }
 
 function closeTab(tab: Tab) {
@@ -674,6 +678,7 @@ async function _loadTabContent(tab: Tab) {
   }
   if (tab.loadingEl) { tab.loadingEl.remove(); tab.loadingEl = null; }
   tab.lastActive = Date.now(); // reset clock so freshly-loaded tabs don't immediately sleep
+  tab._notBeenViewed = true;
   renderTabBar();
   if (activeTab === tab) {
     syncToolButtons(tab.annotator!.tool);
@@ -682,7 +687,7 @@ async function _loadTabContent(tab: Tab) {
     renderToc(tab.outline);
     updatePageDisplay(tab);
     _syncScrollbar();
-    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+    tab._notBeenViewed = false;
     await fitWidth();
   }
 }

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -892,11 +892,11 @@ async function _applyZoomNow(scale: number) {
 async function fitWidth() {
   if (!activeTab) return;
   const v  = activeTab.viewer;
-  const vp = await v.getViewport(1);
+  const { width: pageW } = await v.getPageSize(1);
   const tocW       = tocPanel.classList.contains('hidden') ? 0 : tocPanel.offsetWidth;
   const sbRight    = tocW + SCROLLBAR_GAP + 10; // scrollbar sits left of toc (10px wide) with gap
   const availableW = activeTab.pane.clientWidth - 2 * Math.max(sidebar.offsetWidth, sbRight);
-  await _applyZoomNow(Math.round(((availableW - 32) / (vp.width / v.scale)) * 100) / 100);
+  await _applyZoomNow(Math.round(((availableW - 32) / pageW) * 100) / 100);
 }
 
 async function fitHeight() {

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -892,11 +892,11 @@ async function _applyZoomNow(scale: number) {
 async function fitWidth() {
   if (!activeTab) return;
   const v  = activeTab.viewer;
-  const { width: pageW } = await v.getPageSize(1);
+  const vp = await v.getViewport(1);
   const tocW       = tocPanel.classList.contains('hidden') ? 0 : tocPanel.offsetWidth;
   const sbRight    = tocW + SCROLLBAR_GAP + 10; // scrollbar sits left of toc (10px wide) with gap
   const availableW = activeTab.pane.clientWidth - 2 * Math.max(sidebar.offsetWidth, sbRight);
-  await _applyZoomNow(Math.round(((availableW - 32) / pageW) * 100) / 100);
+  await _applyZoomNow(Math.round(((availableW - 32) / (vp.width / v.scale)) * 100) / 100);
 }
 
 async function fitHeight() {

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -682,6 +682,7 @@ async function _loadTabContent(tab: Tab) {
     renderToc(tab.outline);
     updatePageDisplay(tab);
     _syncScrollbar();
+    await fitWidth();
   }
 }
 

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -86,6 +86,7 @@ export interface Tab {
   _suggestedName?: string | null;
   _savedBytes?: Uint8Array | null;
   _findCache?: Map<number, FindCacheEntry>;
+  _notBeenViewed?: boolean;
 }
 
 // ── CloseContext ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Calls `fitWidth()` at the end of `_loadTabContent` whenever the loaded tab is the active tab
- Only fires on initial load, not on tab switch or wake-from-sleep (those paths don't go through `_loadTabContent`)

Closes #34

## Test plan

- Open a PDF — it should fill the window width immediately
- Open multiple PDFs at once — each should open at fit-width
- Switch between tabs — zoom level persists per tab, no re-fit on switch