### PR TITLE
Add pan tool, horizontal scrollbar, and layout fix for wide documents

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -628,13 +628,13 @@ html, body {
   left: 2px;
   right: 2px;
   border-radius: 4px;
-  background: rgba(255, 255, 255, 0.45);
+  background: rgba(180, 180, 180, 0.6);
   transition: background 0.1s;
   cursor: grab;
   min-height: 30px;
 }
 #viewer-scrollbar-thumb:hover,
-#viewer-scrollbar-thumb.dragging { background: rgba(255, 255, 255, 0.7); cursor: grabbing; }
+#viewer-scrollbar-thumb.dragging { background: rgba(200, 200, 200, 0.85); cursor: grabbing; }
 
 /* ── Horizontal custom scrollbar ─────────────────────────────── */
 #viewer-scrollbar-h {
@@ -652,13 +652,13 @@ html, body {
   top: 2px;
   bottom: 2px;
   border-radius: 4px;
-  background: rgba(255, 255, 255, 0.45);
+  background: rgba(180, 180, 180, 0.6);
   transition: background 0.1s;
   cursor: grab;
   min-width: 30px;
 }
 #viewer-scrollbar-thumb-h:hover,
-#viewer-scrollbar-thumb-h.dragging { background: rgba(255, 255, 255, 0.7); cursor: grabbing; }
+#viewer-scrollbar-thumb-h.dragging { background: rgba(200, 200, 200, 0.85); cursor: grabbing; }
 
 /* ── PDF page container ───────────────────────────────────────── */
 .viewer-pane {
@@ -680,7 +680,7 @@ html, body {
   flex-direction: column;
   align-items: flex-start;
   min-width: 100%;
-  padding: 16px 0;
+  padding: 20px 0;
   gap: 12px;
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -628,13 +628,13 @@ html, body {
   left: 2px;
   right: 2px;
   border-radius: 4px;
-  background: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.45);
   transition: background 0.1s;
   cursor: grab;
   min-height: 30px;
 }
 #viewer-scrollbar-thumb:hover,
-#viewer-scrollbar-thumb.dragging { background: rgba(255, 255, 255, 0.5); cursor: grabbing; }
+#viewer-scrollbar-thumb.dragging { background: rgba(255, 255, 255, 0.7); cursor: grabbing; }
 
 /* ── Horizontal custom scrollbar ─────────────────────────────── */
 #viewer-scrollbar-h {
@@ -652,13 +652,13 @@ html, body {
   top: 2px;
   bottom: 2px;
   border-radius: 4px;
-  background: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.45);
   transition: background 0.1s;
   cursor: grab;
   min-width: 30px;
 }
 #viewer-scrollbar-thumb-h:hover,
-#viewer-scrollbar-thumb-h.dragging { background: rgba(255, 255, 255, 0.5); cursor: grabbing; }
+#viewer-scrollbar-thumb-h.dragging { background: rgba(255, 255, 255, 0.7); cursor: grabbing; }
 
 /* ── PDF page container ───────────────────────────────────────── */
 .viewer-pane {
@@ -678,7 +678,8 @@ html, body {
 .pdf-pages {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
+  min-width: 100%;
   padding: 16px 0;
   gap: 12px;
 }
@@ -687,6 +688,7 @@ html, body {
   position: relative;
   box-shadow: 0 2px 8px rgba(0,0,0,0.5);
   background: #fff;
+  margin: 0 auto;
 }
 
 .pdf-canvas { display: block; }

--- a/assets/style.css
+++ b/assets/style.css
@@ -636,6 +636,30 @@ html, body {
 #viewer-scrollbar-thumb:hover,
 #viewer-scrollbar-thumb.dragging { background: rgba(255, 255, 255, 0.5); cursor: grabbing; }
 
+/* ── Horizontal custom scrollbar ─────────────────────────────── */
+#viewer-scrollbar-h {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 10px;
+  z-index: 15;
+  display: none;
+  cursor: pointer;
+}
+#viewer-scrollbar-thumb-h {
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.25);
+  transition: background 0.1s;
+  cursor: grab;
+  min-width: 30px;
+}
+#viewer-scrollbar-thumb-h:hover,
+#viewer-scrollbar-thumb-h.dragging { background: rgba(255, 255, 255, 0.5); cursor: grabbing; }
+
 /* ── PDF page container ───────────────────────────────────────── */
 .viewer-pane {
   position: absolute;
@@ -648,6 +672,8 @@ html, body {
 }
 .viewer-pane::-webkit-scrollbar { display: none; } /* Chrome/Edge/Safari */
 .viewer-pane.active { display: block; }
+.viewer-pane.pan-active { cursor: grab; }
+.viewer-pane.pan-active.panning { cursor: grabbing; }
 
 .pdf-pages {
   display: flex;
@@ -897,7 +923,7 @@ html, body {
 
 /* ── Print ────────────────────────────────────────────────────── */
 @media print {
-  #topbar, #sidebar, #toc-panel, #empty-state, #viewer-scrollbar { display: none !important; }
+  #topbar, #sidebar, #toc-panel, #empty-state, #viewer-scrollbar, #viewer-scrollbar-h { display: none !important; }
   #content-area { position: static; overflow: visible; }
   #viewer-host  { position: static; overflow: visible; }
   .viewer-pane  { display: none; position: static; overflow: visible; }

--- a/assets/style.css
+++ b/assets/style.css
@@ -616,8 +616,8 @@ html, body {
 #viewer-scrollbar {
   position: absolute;
   right: 0;
-  top: 0;
-  bottom: 0;
+  top: 4px;
+  bottom: 4px;
   width: 10px;
   z-index: 15;
   display: none;

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -134,6 +134,14 @@
           <path d="M6.5 17.5l4-4"/>
         </svg>
       </button>
+
+      <span class="sep"></span>
+
+      <button id="tool-pan" class="tool-btn" title="Pan (P)" data-tool="pan">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M18 11V8a2 2 0 0 0-4 0v1a2 2 0 0 0-4 0V7a2 2 0 0 0-4 0v6l-1.5-1.5a2 2 0 0 0-2.83 2.83L6 20h12v-3a4 4 0 0 0-4-4h4z"/>
+        </svg>
+      </button>
     </div>
 
     <!-- CENTER: page navigation -->
@@ -209,6 +217,11 @@
       <div id="empty-state">
         <p>No file open.<br>Press <kbd>Ctrl+O</kbd> to open a PDF.</p>
       </div>
+    </div>
+
+    <!-- Horizontal scrollbar (shown only when content overflows horizontally) -->
+    <div id="viewer-scrollbar-h">
+      <div id="viewer-scrollbar-thumb-h"></div>
     </div>
 
     <!-- Left sidebar: permanent overlay -->

--- a/src/renderer/annotator.ts
+++ b/src/renderer/annotator.ts
@@ -837,6 +837,7 @@ export class Annotator {
       oval:      'crosshair',
       arrow:     'crosshair',
       eraser:    'cell',
+      pan:       'inherit', // pane-level cursor handles grab/grabbing
     };
     this.pages.forEach(p => {
       p.annotCanvas.style.cursor = (cursors as Record<string, string>)[this.tool] || 'default';

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -38,6 +38,18 @@ let _sbDragging        = false;
 let _sbDragStartY      = 0;
 let _sbDragStartScroll = 0;
 
+// Horizontal scrollbar drag state
+let _sbhDragging        = false;
+let _sbhDragStartX      = 0;
+let _sbhDragStartScroll = 0;
+
+// Pan tool drag state
+let _panDragging        = false;
+let _panStartX          = 0;
+let _panStartY          = 0;
+let _panStartScrollLeft = 0;
+let _panStartScrollTop  = 0;
+
 // Native file drag state (drag-to-external-app)
 let _nativeDrag: { filePath: string; x: number; y: number } | null = null; // { filePath, x, y } while tracking mousedown before threshold
 
@@ -49,9 +61,11 @@ let myWindowId: number | null = null;
 
 // ── DOM refs ───────────────────────────────────────────────────
 
-const sidebar              = document.getElementById('sidebar')!;
-const viewerScrollbar      = document.getElementById('viewer-scrollbar')!;
-const viewerScrollbarThumb = document.getElementById('viewer-scrollbar-thumb')!;
+const sidebar               = document.getElementById('sidebar')!;
+const viewerScrollbar       = document.getElementById('viewer-scrollbar')!;
+const viewerScrollbarThumb  = document.getElementById('viewer-scrollbar-thumb')!;
+const viewerScrollbarH      = document.getElementById('viewer-scrollbar-h')!;
+const viewerScrollbarThumbH = document.getElementById('viewer-scrollbar-thumb-h')!;
 const tabBar         = document.getElementById('tab-bar')!;
 const toolsPanel     = document.getElementById('tools-panel')!;
 const viewerHost     = document.getElementById('viewer-host')!;
@@ -142,6 +156,70 @@ function _positionScrollbar() {
   viewerScrollbar.style.right = `${base + SCROLLBAR_GAP}px`;
   _syncScrollbar();
 }
+
+// ── Horizontal scrollbar ───────────────────────────────────────
+
+function _syncScrollbarH() {
+  if (!activeTab) { viewerScrollbarH.style.display = 'none'; return; }
+  const pane    = activeTab.pane;
+  const scrollW = pane.scrollWidth;
+  const clientW = pane.clientWidth;
+  if (scrollW <= clientW) { viewerScrollbarH.style.display = 'none'; return; }
+  viewerScrollbarH.style.display = 'block';
+  const trackW      = viewerScrollbarH.clientWidth;
+  const thumbW      = Math.max(30, Math.round((clientW / scrollW) * trackW));
+  const maxScroll   = scrollW - clientW;
+  const maxThumbLeft = trackW - thumbW;
+  const thumbLeft   = Math.round((pane.scrollLeft / maxScroll) * maxThumbLeft);
+  viewerScrollbarThumbH.style.width = `${thumbW}px`;
+  viewerScrollbarThumbH.style.left  = `${thumbLeft}px`;
+}
+
+function _positionScrollbarH() {
+  const tocW = !tocPanel.classList.contains('hidden') ? tocPanel.offsetWidth : 0;
+  viewerScrollbarH.style.left  = `${sidebar.offsetWidth}px`;
+  viewerScrollbarH.style.right = `${tocW + SCROLLBAR_GAP + 10}px`;
+  _syncScrollbarH();
+}
+
+// When content overflows horizontally, pad pdf-pages so the document's left edge
+// can be scrolled flush with the sidebar and the right edge flush with the TOC.
+function _updateHorizontalPadding() {
+  if (!activeTab) return;
+  const pane    = activeTab.pane;
+  const pagesEl = pane.querySelector('.pdf-pages') as HTMLElement | null;
+  if (!pagesEl) return;
+  const scrollW = pane.scrollWidth;
+  const clientW = pane.clientWidth;
+  if (scrollW > clientW) {
+    const tocW = !tocPanel.classList.contains('hidden') ? tocPanel.offsetWidth : 0;
+    pagesEl.style.paddingLeft  = `${sidebar.offsetWidth}px`;
+    pagesEl.style.paddingRight = `${tocW}px`;
+  } else {
+    pagesEl.style.paddingLeft  = '';
+    pagesEl.style.paddingRight = '';
+  }
+}
+
+// Jump scroll on track click (not thumb)
+viewerScrollbarH.addEventListener('mousedown', (e) => {
+  if (e.target === viewerScrollbarThumbH || !activeTab) return;
+  const rect  = viewerScrollbarH.getBoundingClientRect();
+  const ratio = (e.clientX - rect.left) / rect.width;
+  activeTab.pane.scrollLeft = ratio * (activeTab.pane.scrollWidth - activeTab.pane.clientWidth);
+});
+
+// Thumb drag start
+viewerScrollbarThumbH.addEventListener('mousedown', (e) => {
+  if (e.button !== 0) return;
+  e.preventDefault();
+  e.stopPropagation();
+  _sbhDragging        = true;
+  _sbhDragStartX      = e.clientX;
+  _sbhDragStartScroll = activeTab?.pane.scrollLeft ?? 0;
+  viewerScrollbarThumbH.classList.add('dragging');
+  document.body.style.userSelect = 'none';
+});
 
 // Jump scroll on track click (not thumb)
 viewerScrollbar.addEventListener('mousedown', (e) => {
@@ -249,10 +327,14 @@ document.addEventListener('mousemove', (e) => {
   if (_resizingSidebar) {
     const w = Math.max(SIDEBAR_MIN, e.clientX);
     sidebar.style.width = w + 'px';
+    _positionScrollbarH();
+    _updateHorizontalPadding();
   }
   if (_resizingToc) {
     const w = Math.max(TOC_MIN, window.innerWidth - e.clientX);
     tocPanel.style.width = w + 'px';
+    _positionScrollbarH();
+    _updateHorizontalPadding();
   }
   if (_sbDragging && activeTab) {
     const pane       = activeTab.pane;
@@ -263,6 +345,23 @@ document.addEventListener('mousemove', (e) => {
     const dy         = e.clientY - _sbDragStartY;
     const maxScroll  = pane.scrollHeight - pane.clientHeight;
     pane.scrollTop   = _sbDragStartScroll + (dy / maxTravel) * maxScroll;
+  }
+  if (_sbhDragging && activeTab) {
+    const pane       = activeTab.pane;
+    const trackW     = viewerScrollbarH.clientWidth;
+    const thumbW     = viewerScrollbarThumbH.offsetWidth;
+    const maxTravel  = trackW - thumbW;
+    if (maxTravel <= 0) return;
+    const dx         = e.clientX - _sbhDragStartX;
+    const maxScroll  = pane.scrollWidth - pane.clientWidth;
+    pane.scrollLeft  = _sbhDragStartScroll + (dx / maxTravel) * maxScroll;
+  }
+  if (_panDragging && activeTab) {
+    const pane = activeTab.pane;
+    pane.scrollLeft = _panStartScrollLeft - (e.clientX - _panStartX);
+    pane.scrollTop  = _panStartScrollTop  - (e.clientY - _panStartY);
+    _syncScrollbar();
+    _syncScrollbarH();
   }
   if (_nativeDrag) {
     const dx = e.clientX - _nativeDrag.x;
@@ -281,6 +380,8 @@ document.addEventListener('mouseup', () => {
     sidebarResizeHandle.classList.remove('resizing');
     document.body.style.cursor     = '';
     document.body.style.userSelect = '';
+    _positionScrollbarH();
+    _updateHorizontalPadding();
   }
   if (_resizingToc) {
     _resizingToc = false;
@@ -289,11 +390,23 @@ document.addEventListener('mouseup', () => {
     document.body.style.cursor     = '';
     document.body.style.userSelect = '';
     _positionScrollbar();
+    _positionScrollbarH();
+    _updateHorizontalPadding();
   }
   _nativeDrag = null;
   if (_sbDragging) {
     _sbDragging = false;
     viewerScrollbarThumb.classList.remove('dragging');
+    document.body.style.userSelect = '';
+  }
+  if (_sbhDragging) {
+    _sbhDragging = false;
+    viewerScrollbarThumbH.classList.remove('dragging');
+    document.body.style.userSelect = '';
+  }
+  if (_panDragging && activeTab) {
+    _panDragging = false;
+    activeTab.pane.classList.remove('panning');
     document.body.style.userSelect = '';
   }
 });
@@ -529,6 +642,7 @@ function switchTab(tab: Tab) {
   updatePageDisplay(tab);
   attachScrollListener(tab);
   _positionScrollbar();
+  _positionScrollbarH();
   finder.onTabSwitch();
 }
 
@@ -682,6 +796,7 @@ async function _loadTabContent(tab: Tab) {
     renderToc(tab.outline);
     updatePageDisplay(tab);
     _syncScrollbar();
+    _positionScrollbarH();
   }
 }
 
@@ -885,6 +1000,8 @@ async function _applyZoomNow(scale: number) {
   activeTab.annotator!.pages = v.pages;
   activeTab.annotator!.redrawAll();
   _syncScrollbar();
+  _updateHorizontalPadding();
+  _syncScrollbarH();
   finder.onZoom();
 }
 
@@ -932,9 +1049,24 @@ function updatePageDisplay(tab: Tab | null) {
 
 function attachScrollListener(tab: Tab) {
   if (_paneScrollCleanup) _paneScrollCleanup();
-  const handler = () => { updatePageDisplay(tab); _syncScrollbar(); };
-  tab.pane.addEventListener('scroll', handler, { passive: true });
-  _paneScrollCleanup = () => tab.pane.removeEventListener('scroll', handler);
+  const scrollHandler = () => { updatePageDisplay(tab); _syncScrollbar(); _syncScrollbarH(); };
+  const panHandler = (e: MouseEvent) => {
+    if (e.button !== 0 || activeTab?.annotator?.tool !== 'pan') return;
+    e.preventDefault();
+    _panDragging        = true;
+    _panStartX          = e.clientX;
+    _panStartY          = e.clientY;
+    _panStartScrollLeft = tab.pane.scrollLeft;
+    _panStartScrollTop  = tab.pane.scrollTop;
+    tab.pane.classList.add('panning');
+    document.body.style.userSelect = 'none';
+  };
+  tab.pane.addEventListener('scroll',     scrollHandler, { passive: true });
+  tab.pane.addEventListener('mousedown',  panHandler);
+  _paneScrollCleanup = () => {
+    tab.pane.removeEventListener('scroll',    scrollHandler);
+    tab.pane.removeEventListener('mousedown', panHandler);
+  };
 }
 
 function jumpToPage(pageNum: number) {
@@ -1016,6 +1148,7 @@ function syncToolButtons(tool: string) {
   document.querySelectorAll('.tool-btn').forEach(btn => {
     btn.classList.toggle('active', (btn as HTMLElement).dataset.tool === tool);
   });
+  if (activeTab) activeTab.pane.classList.toggle('pan-active', tool === 'pan');
 }
 
 function syncTextFormatButtons(annotator: Annotator) {
@@ -1119,7 +1252,7 @@ document.addEventListener('keydown', async (e) => {
 
   const toolMap = {
     d: 'draw', h: 'highlight', t: 'text', Escape: 'select',
-    l: 'line', r: 'rect', o: 'oval', a: 'arrow', e: 'eraser',
+    l: 'line', r: 'rect', o: 'oval', a: 'arrow', e: 'eraser', p: 'pan',
   };
   const tool = (toolMap as Record<string, string>)[e.key];
   if (tool) {

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1078,12 +1078,16 @@ function renderToc(outline: OutlineNode[] | null) {
     tocPanel.classList.add('hidden');
     contentArea.classList.remove('toc-open');
     _positionScrollbar();
+    _positionScrollbarH();
+    _updateHorizontalPadding();
     return;
   }
   tocPanel.classList.remove('hidden');
   contentArea.classList.add('toc-open');
   _buildTocNodes(outline, tocTree);
   _positionScrollbar();
+  _positionScrollbarH();
+  _updateHorizontalPadding();
 }
 
 function _buildTocNodes(items: OutlineNode[], container: HTMLElement) {

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -190,8 +190,9 @@ function _updateHorizontalPadding() {
   const pagesEl = pane.querySelector('.pdf-pages') as HTMLElement | null;
   if (!pagesEl) return;
   const tocW = !tocPanel.classList.contains('hidden') ? tocPanel.offsetWidth : 0;
-  pagesEl.style.paddingLeft  = `${sidebar.offsetWidth}px`;
-  pagesEl.style.paddingRight = `${tocW}px`;
+  const edgePad = 20;
+  pagesEl.style.paddingLeft  = `${sidebar.offsetWidth + edgePad}px`;
+  pagesEl.style.paddingRight = `${tocW + edgePad}px`;
 }
 
 // Jump scroll on track click (not thumb)

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -177,8 +177,8 @@ function _syncScrollbarH() {
 
 function _positionScrollbarH() {
   const tocW = !tocPanel.classList.contains('hidden') ? tocPanel.offsetWidth : 0;
-  viewerScrollbarH.style.left  = `${sidebar.offsetWidth}px`;
-  viewerScrollbarH.style.right = `${tocW + SCROLLBAR_GAP + 10}px`;
+  viewerScrollbarH.style.left  = `${sidebar.offsetWidth + 4}px`;
+  viewerScrollbarH.style.right = `${tocW + SCROLLBAR_GAP + 10 + 4}px`;
   _syncScrollbarH();
 }
 

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -182,23 +182,16 @@ function _positionScrollbarH() {
   _syncScrollbarH();
 }
 
-// When content overflows horizontally, pad pdf-pages so the document's left edge
-// can be scrolled flush with the sidebar and the right edge flush with the TOC.
+// Pad pdf-pages so the document can be scrolled until its edges are visible
+// past the sidebar and TOC panel. Always applied so margin:auto centering works.
 function _updateHorizontalPadding() {
   if (!activeTab) return;
   const pane    = activeTab.pane;
   const pagesEl = pane.querySelector('.pdf-pages') as HTMLElement | null;
   if (!pagesEl) return;
-  const scrollW = pane.scrollWidth;
-  const clientW = pane.clientWidth;
-  if (scrollW > clientW) {
-    const tocW = !tocPanel.classList.contains('hidden') ? tocPanel.offsetWidth : 0;
-    pagesEl.style.paddingLeft  = `${sidebar.offsetWidth}px`;
-    pagesEl.style.paddingRight = `${tocW}px`;
-  } else {
-    pagesEl.style.paddingLeft  = '';
-    pagesEl.style.paddingRight = '';
-  }
+  const tocW = !tocPanel.classList.contains('hidden') ? tocPanel.offsetWidth : 0;
+  pagesEl.style.paddingLeft  = `${sidebar.offsetWidth}px`;
+  pagesEl.style.paddingRight = `${tocW}px`;
 }
 
 // Jump scroll on track click (not thumb)


### PR DESCRIPTION
## Summary

- **Pan tool** — hand icon in the toolbar (shortcut `P`). Clicking and dragging scrolls the document in both axes. The pane cursor switches to grab/grabbing to match.
- **Horizontal scrollbar** — custom element mirroring the existing vertical one, shown only when the page is wider than the visible area. Supports click-to-jump and thumb drag. Hidden during print.
- **Layout fix** — when content overflows horizontally, `padding-left/right` is added to `.pdf-pages` equal to the sidebar and TOC widths. This ensures scrolling all the way left puts the document's left edge flush with the sidebar rather than hidden under it. Padding is removed when at or below fit-width zoom.
- Horizontal scrollbar and padding update on zoom changes and tab sidebar resize. TOC still broken.

Updates #35

## Test plan

- Zoom into a wide document — horizontal scrollbar appears at the bottom between the two sidebars
- Drag horizontal scrollbar thumb left/right — view scrolls accordingly
- Scroll (or pan) all the way left — document left edge lands at the sidebar right edge, not under it
- Select pan tool (button or `P`) — cursor becomes a hand; dragging scrolls both axes
- Zoom back to fit-width — horizontal scrollbar disappears and padding is cleared
- Resize sidebar/TOC while zoomed in — scrollbar repositions correctly