### PR TITLE
Fix tab drag creating a new window on drag-out then drag-back

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -466,7 +466,8 @@ tabBar.addEventListener('drop', async (e) => {
   const filepath = e.dataTransfer!.getData('reamlet-tab-filepath');
   const sourceId = Number(e.dataTransfer!.getData('reamlet-tab-source-id'));
   const isDirty  = e.dataTransfer!.getData('reamlet-tab-dirty') === '1';
-  if (!filepath || sourceId === myWindowId) return; // same window handled by tab elements
+  if (!filepath) return;
+  if (sourceId === myWindowId) { _dropHandled = true; return; } // same window — prevent new-window fallback
 
   e.preventDefault();
   _dropHandled = true;


### PR DESCRIPTION
## Summary

When a tab is dragged outside the window and then dragged back in and dropped on the empty tab bar area (not on a specific tab element), `tabBar.drop` fires but returned early because `sourceId === myWindowId`, leaving `_dropHandled = false`. The `dragend` handler then started the 500ms new-window timer.

The fix marks the drop as handled when the source is the same window, so `dragend` sees `handled = true` and the new-window timer is never started. The tab stays in place.

Dragging a tab out and releasing outside the window still creates a new window (the timer fires normally; `sourceId` check is never reached in that path).

## Test plan

- Grab a tab, drag it out of the window, drag it back over the tab bar, release — tab should stay in place, no new window
- Grab a tab, drag it out of the window, release outside — new window should still be created