### PR TITLE
Fix paste and right-click menu in Extension ID dialog

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -938,7 +938,8 @@ html, body {
 }
 
 /* ── Context menu ─────────────────────────────────────────────── */
-#context-menu {
+#context-menu,
+#input-ctx-menu {
   position: fixed;
   z-index: 1000;
   background: var(--bar-bg);
@@ -948,9 +949,11 @@ html, body {
   padding: 4px;
   min-width: 140px;
 }
-#context-menu.hidden { display: none; }
+#context-menu.hidden,
+#input-ctx-menu.hidden { display: none; }
 
-#context-menu button {
+#context-menu button,
+#input-ctx-menu button {
   display: block;
   width: 100%;
   background: transparent;
@@ -962,9 +965,12 @@ html, body {
   border-radius: 3px;
   text-align: left;
 }
-#context-menu button:hover { background: var(--accent); color: #fff; }
-#context-menu button:disabled { opacity: 0.4; cursor: default; }
-#context-menu button:disabled:hover { background: transparent; color: var(--text); }
+#context-menu button:hover,
+#input-ctx-menu button:hover { background: var(--accent); color: #fff; }
+#context-menu button:disabled,
+#input-ctx-menu button:disabled { opacity: 0.4; cursor: default; }
+#context-menu button:disabled:hover,
+#input-ctx-menu button:disabled:hover { background: transparent; color: var(--text); }
 
 /* ── Tab context menu ──────────────────────────────────────────── */
 #tab-context-menu {

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -378,6 +378,13 @@
     <button data-ctx="find">Find</button>
   </div>
 
+  <!-- ── Input context menu ───────────────────────────────────── -->
+  <div id="input-ctx-menu" class="hidden">
+    <button data-input-ctx="cut">Cut</button>
+    <button data-input-ctx="copy">Copy</button>
+    <button data-input-ctx="paste">Paste</button>
+  </div>
+
   <!-- ── Tab context menu ──────────────────────────────────────── -->
   <div id="tab-context-menu" class="hidden">
     <button data-tctx="close">Close</button>

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -87,6 +87,7 @@ const colorDot       = document.getElementById('color-dot')!;
 const colorPanel     = document.getElementById('color-panel')!;
 const titleFilename  = document.getElementById('title-filename')!;
 const contextMenu    = document.getElementById('context-menu')!;
+const inputCtxMenu   = document.getElementById('input-ctx-menu')!;
 const ctxCut         = document.querySelector('[data-ctx="cut"]')   as HTMLButtonElement;
 const ctxPaste       = document.querySelector('[data-ctx="paste"]') as HTMLButtonElement;
 const tabContextMenu = document.getElementById('tab-context-menu')!;
@@ -287,6 +288,7 @@ viewerHost.addEventListener('contextmenu', (e) => {
 document.addEventListener('mousedown', (e) => {
   if (!(e.target as Element)?.closest('#context-menu'))     _hideContextMenu();
   if (!(e.target as Element)?.closest('#tab-context-menu')) _hideTabContextMenu();
+  if (!(e.target as Element)?.closest('#input-ctx-menu'))   inputCtxMenu.classList.add('hidden');
 });
 
 contextMenu.addEventListener('mousedown', (e) => {
@@ -1309,6 +1311,8 @@ document.addEventListener('keydown', async (e) => {
   if (ctrl && (e.key === '=' || e.key === '+')) { e.preventDefault(); zoom(0.1); return; }
   if (ctrl && e.key === '-') { e.preventDefault(); zoom(-0.1); return; }
   if (ctrl && e.key === '0') { e.preventDefault(); fitWidth(); return; }
+  if (document.activeElement?.tagName === 'INPUT' || document.activeElement?.tagName === 'TEXTAREA') return;
+
   if (ctrl && e.key === 'z') { e.preventDefault(); activeTab?.annotator?.undo(); return; }
   if (ctrl && (e.key === 'y' || (e.shiftKey && e.key === 'Z'))) { e.preventDefault(); activeTab?.annotator?.redo(); return; }
   if (ctrl && e.key === 'x') { e.preventDefault(); activeTab?.annotator?.cut(); return; }
@@ -1435,6 +1439,41 @@ document.getElementById('ext-id-save')!.addEventListener('click', async () => {
     document.getElementById('ext-id-modal')!.classList.add('hidden');
   } else {
     alert('Failed to save: ' + result.error);
+  }
+});
+
+document.getElementById('ext-id-input')!.addEventListener('contextmenu', (e) => {
+  e.preventDefault();
+  e.stopPropagation();
+  inputCtxMenu.classList.remove('hidden');
+  const menuW = inputCtxMenu.offsetWidth  || 120;
+  const menuH = inputCtxMenu.offsetHeight || 80;
+  inputCtxMenu.style.left = `${Math.max(0, Math.min(e.clientX, window.innerWidth  - menuW - 4))}px`;
+  inputCtxMenu.style.top  = `${Math.max(0, Math.min(e.clientY, window.innerHeight - menuH - 4))}px`;
+});
+
+inputCtxMenu.addEventListener('mousedown', (e) => {
+  const btn = (e.target as Element)?.closest('[data-input-ctx]') as HTMLElement | null;
+  if (!btn) return;
+  e.preventDefault();
+  inputCtxMenu.classList.add('hidden');
+  const input = document.getElementById('ext-id-input') as HTMLInputElement;
+  input.focus();
+  const start = input.selectionStart ?? 0;
+  const end   = input.selectionEnd   ?? 0;
+  switch (btn.dataset.inputCtx) {
+    case 'cut':
+      navigator.clipboard.writeText(input.value.substring(start, end));
+      input.setRangeText('', start, end, 'end');
+      break;
+    case 'copy':
+      navigator.clipboard.writeText(input.value.substring(start, end));
+      break;
+    case 'paste':
+      navigator.clipboard.readText().then(text => {
+        input.setRangeText(text, input.selectionStart ?? 0, input.selectionEnd ?? 0, 'end');
+      });
+      break;
   }
 });
 


### PR DESCRIPTION
Fixes #44

## Summary
- The global `keydown` handler intercepted `Ctrl+V`, `Ctrl+X`, `Ctrl+C`, `Ctrl+Z`, and `Ctrl+Y` before checking whether an input field was focused, preventing native clipboard and undo operations in the Extension ID dialog
- Moved the `INPUT`/`TEXTAREA` guard earlier in the handler so all annotation shortcuts are skipped when an input is focused
- Added a right-click Cut / Copy / Paste context menu to the Extension ID input, styled consistently with the existing context menus

## Test plan
- Open Extension ID dialog, right-click the input — Cut / Copy / Paste menu should appear and work
- Ctrl+V in the input should paste from clipboard
- Ctrl+X / Ctrl+C should cut/copy selected text in the input
- Ctrl+Z / Ctrl+Y should undo/redo text changes natively in the input
- With the dialog closed, Ctrl+V with an annotation in the clipboard should still paste the annotation onto the PDF