### PR TITLE
Fix annotation coordinates wrong on rotated pages

### DIFF
--- a/src/renderer/annotator.ts
+++ b/src/renderer/annotator.ts
@@ -117,6 +117,38 @@ export class Annotator {
     this.pages.forEach((p, idx) => this._redrawPage(p, idx + 1));
   }
 
+  /**
+   * Transform stored annotation coordinates to match a 90° CW rotation applied
+   * to the given page (or all pages when pageNum is null).
+   * Must be called before redrawAll() / page re-render after rotation.
+   */
+  rotateAnnotations(pageNum: number | null, cwDegrees: number) {
+    const steps = (Math.round(cwDegrees / 90) % 4 + 4) % 4;
+    const targets = this.annotations.filter(a => pageNum === null || a.pageNum === pageNum);
+    for (let s = 0; s < steps; s++) {
+      for (const ann of targets) {
+        if (ann.type === 'draw' || ann.type === 'freeHighlight') {
+          ann.points = (ann.points as [number, number][]).map(([nx, ny]) => [1 - ny, nx]);
+        } else if (ann.type === 'highlight') {
+          ann.rects = ann.rects.map(r => ({
+            x: 1 - (r.y + r.height),
+            y: r.x,
+            width: r.height,
+            height: r.width,
+          }));
+        } else if (ann.type === 'text') {
+          const { x, y } = ann;
+          ann.x = 1 - y;
+          ann.y = x;
+        } else if (ann.type === 'line' || ann.type === 'arrow' || ann.type === 'rect' || ann.type === 'oval') {
+          const { x1, y1, x2, y2 } = ann;
+          ann.x1 = 1 - y1; ann.y1 = x1;
+          ann.x2 = 1 - y2; ann.y2 = x2;
+        }
+      }
+    }
+  }
+
   undo() {
     if (this._histIdx <= 0) return;
     this._histIdx--;

--- a/src/renderer/annotator.ts
+++ b/src/renderer/annotator.ts
@@ -219,7 +219,7 @@ export class Annotator {
             pageNum:   fh.pageNum,
             points:    fh.points,
             color:     this.color,
-            thickness: 20,
+            thickness: 20 / (this.viewer?.scale ?? 1),
           });
           this._pushHistory();
         }
@@ -341,12 +341,13 @@ export class Annotator {
         this._drawing = false;
         if (this._currentPath && this._currentPath.points.length > 1) {
           const w = canvas.width, h = canvas.height;
+          const scale = this.viewer?.scale ?? 1;
           this.annotations.push({
             type:      'draw',
             pageNum,
             points:    this._currentPath.points.map(([x, y]) => [x / w, y / h]),
             color:     this._currentPath.color,
-            thickness: this._currentPath.thickness,
+            thickness: this._currentPath.thickness / scale,
           });
           this._pushHistory();
         }
@@ -358,12 +359,13 @@ export class Annotator {
         this._shapeStart = null;
         if (Math.abs(x2 - x1) > 2 || Math.abs(y2 - y1) > 2) {
           const w = canvas.width, h = canvas.height;
+          const scale = this.viewer?.scale ?? 1;
           this.annotations.push({
             type: this.tool as ShapeAnnotation['type'], pageNum,
             x1: x1 / w, y1: y1 / h,
             x2: x2 / w, y2: y2 / h,
             color:     this.color,
-            thickness: this.thickness,
+            thickness: this.thickness / scale,
           });
           this._pushHistory();
         }
@@ -399,12 +401,13 @@ export class Annotator {
       this._drawing = false;
       if (this._currentPath && this._currentPath.points.length > 1) {
         const w = canvas.width, h = canvas.height;
+        const scale = this.viewer?.scale ?? 1;
         this.annotations.push({
           type:      'draw',
           pageNum,
           points:    this._currentPath.points.map(([x, y]) => [x / w, y / h]),
           color:     this._currentPath.color,
-          thickness: this._currentPath.thickness,
+          thickness: this._currentPath.thickness / scale,
         });
         this._pushHistory();
       }
@@ -864,10 +867,11 @@ export class Annotator {
   }
 
   _drawAnnotation(ctx: CanvasRenderingContext2D, annot: Annotation, w: number, h: number) {
+    const scale = this.viewer?.scale ?? 1;
     ctx.save();
     if (annot.type === 'draw') {
       ctx.strokeStyle = annot.color;
-      ctx.lineWidth   = annot.thickness;
+      ctx.lineWidth   = annot.thickness * scale;
       ctx.lineCap     = 'round';
       ctx.lineJoin    = 'round';
       ctx.beginPath();
@@ -880,7 +884,7 @@ export class Annotator {
     } else if (annot.type === 'freeHighlight') {
       ctx.globalAlpha = 0.35;
       ctx.strokeStyle = annot.color;
-      ctx.lineWidth   = annot.thickness;
+      ctx.lineWidth   = annot.thickness * scale;
       ctx.lineCap     = 'round';
       ctx.lineJoin    = 'round';
       ctx.beginPath();
@@ -915,7 +919,7 @@ export class Annotator {
 
     } else if (annot.type === 'line' || annot.type === 'rect' || annot.type === 'oval' || annot.type === 'arrow') {
       ctx.strokeStyle = annot.color;
-      ctx.lineWidth   = annot.thickness;
+      ctx.lineWidth   = annot.thickness * scale;
       ctx.lineCap     = 'round';
       ctx.lineJoin    = 'round';
       this._drawShape(ctx, annot.type, annot.x1 * w, annot.y1 * h, annot.x2 * w, annot.y2 * h);

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1066,6 +1066,7 @@ async function _applyZoomNow(scale: number) {
   await v.setZoom(scale);
   activeTab.annotator!.pages = v.pages;
   activeTab.annotator!.redrawAll();
+  activeTab.annotator!.setTool(activeTab.annotator!.tool);
   _syncScrollbar();
   _updateHorizontalPadding();
   _syncScrollbarH();
@@ -1098,6 +1099,7 @@ async function rotate(singlePage: boolean) {
   else            await v.rotateAll(90);
   activeTab.annotator!.pages = v.pages;
   activeTab.annotator!.redrawAll();
+  activeTab.annotator!.setTool(activeTab.annotator!.tool);
   markDirty(activeTab);
 }
 

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1095,8 +1095,10 @@ async function fitHeight() {
 async function rotate(singlePage: boolean) {
   if (!activeTab) return;
   const v = activeTab.viewer;
+  const targetPage = singlePage ? v.getVisiblePageNum() : null;
   if (singlePage) await v.rotatePage(v.getVisiblePageNum(), 90);
   else            await v.rotateAll(90);
+  activeTab.annotator!.rotateAnnotations(targetPage, 90);
   activeTab.annotator!.pages = v.pages;
   activeTab.annotator!.redrawAll();
   activeTab.annotator!.setTool(activeTab.annotator!.tool);

--- a/src/renderer/saver.ts
+++ b/src/renderer/saver.ts
@@ -86,15 +86,15 @@ export async function embedAnnotations(pdfBytes: Uint8Array, annotations: Annota
  * Rotation is the total display rotation (base PDF /Rotate + user rotation).
  * Formulas derived from inverting the PDF.js viewport transform:
  *   rot=0:   pdf = (nx·W,     (1-ny)·H)
- *   rot=90:  pdf = ((1-ny)·W, (1-nx)·H)
+ *   rot=90:  pdf = (ny·W,     nx·H)
  *   rot=180: pdf = ((1-nx)·W, ny·H)
- *   rot=270: pdf = (ny·W,     nx·H)
+ *   rot=270: pdf = ((1-ny)·W, (1-nx)·H)
  */
 function toPdfCoords(nx: number, ny: number, pdfW: number, pdfH: number, rot: number): [number, number] {
   switch ((rot || 0) % 360) {
-    case 90:  return [(1 - ny) * pdfW, (1 - nx) * pdfH];
+    case 90:  return [       ny * pdfW,        nx * pdfH];
     case 180: return [(1 - nx) * pdfW,        ny * pdfH];
-    case 270: return [       ny * pdfW,        nx * pdfH];
+    case 270: return [(1 - ny) * pdfW, (1 - nx) * pdfH];
     default:  return [       nx * pdfW, (1 - ny) * pdfH];
   }
 }

--- a/src/renderer/saver.ts
+++ b/src/renderer/saver.ts
@@ -61,17 +61,16 @@ export async function embedAnnotations(pdfBytes: Uint8Array, annotations: Annota
 
     const { width: pdfW, height: pdfH } = await viewer.getPageSize(pageNum);
     const totalRot = viewer.getTotalRotation(pageNum);
-    const scale    = viewer.scale;
 
     for (const ann of pageAnns) {
-      if      (ann.type === 'draw')          _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
-      else if (ann.type === 'freeHighlight') _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
+      if      (ann.type === 'draw')          _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot);
+      else if (ann.type === 'freeHighlight') _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot);
       else if (ann.type === 'highlight')     _addHighlightAnnotation(pdfPage, ann,           pdfW, pdfH, totalRot);
       else if (ann.type === 'text')          _addFreeTextAnnotation (pdfPage, ann,           pdfW, pdfH, totalRot);
-      else if (ann.type === 'line')          _addLineAnnotation     (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
-      else if (ann.type === 'arrow')         _addArrowAnnotation    (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
-      else if (ann.type === 'rect')          _addSquareAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
-      else if (ann.type === 'oval')          _addCircleAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
+      else if (ann.type === 'line')          _addLineAnnotation     (pdfPage, ann,           pdfW, pdfH, totalRot);
+      else if (ann.type === 'arrow')         _addArrowAnnotation    (pdfPage, ann,           pdfW, pdfH, totalRot);
+      else if (ann.type === 'rect')          _addSquareAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot);
+      else if (ann.type === 'oval')          _addCircleAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot);
     }
   }
 
@@ -109,9 +108,8 @@ function hexToRgb01(hex: string): { r: number; g: number; b: number } {
 
 // ── Annotation writers ───────────────────────────────────────
 
-function _addInkAnnotation(pdfPage: PDFPage, ann: DrawAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
+function _addInkAnnotation(pdfPage: PDFPage, ann: DrawAnnotation, pdfW: number, pdfH: number, rot: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
-  const w = ann.thickness / scale; // canvas px → PDF pts
 
   const inkPoints = ann.points.flatMap(([nx, ny]: [number, number]) => {
     const [x, y] = toPdfCoords(nx, ny, pdfW, pdfH, rot);
@@ -123,14 +121,14 @@ function _addInkAnnotation(pdfPage: PDFPage, ann: DrawAnnotation, pdfW: number, 
   const pdfPts = ann.points.map(([nx, ny]: [number, number]) => toPdfCoords(nx, ny, pdfW, pdfH, rot));
   const xs  = pdfPts.map(([x]: [number, number]) => x);
   const ys  = pdfPts.map(([, y]: [number, number]) => y);
-  const pad = w;
+  const pad = ann.thickness;
 
   const annotDict = pdfPage.doc.context.obj({
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Ink'),
     Rect:    [Math.min(...xs) - pad, Math.min(...ys) - pad, Math.max(...xs) + pad, Math.max(...ys) + pad],
     InkList: inkList,
-    BS:      pdfPage.doc.context.obj({ W: w }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
     C:       [r, g, b],
     CA:      PDFNumber.of(ann.type === 'freeHighlight' ? 0.4 : 1),
     F:       PDFNumber.of(4),
@@ -190,44 +188,42 @@ function _addFreeTextAnnotation(pdfPage: PDFPage, ann: TextAnnotation, pdfW: num
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addLineAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
+function _addLineAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
-  const w   = ann.thickness / scale;
-  const pad = w;
+  const pad = ann.thickness;
   const annotDict = pdfPage.doc.context.obj({
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Line'),
     Rect:    [Math.min(x1,x2)-pad, Math.min(y1,y2)-pad, Math.max(x1,x2)+pad, Math.max(y1,y2)+pad],
     L:       [x1, y1, x2, y2],
-    BS:      pdfPage.doc.context.obj({ W: w }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addArrowAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
+function _addArrowAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
-  const w   = ann.thickness / scale;
-  const pad = w * 5;
+  const pad = ann.thickness * 5;
   const annotDict = pdfPage.doc.context.obj({
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Line'),
     Rect:    [Math.min(x1,x2)-pad, Math.min(y1,y2)-pad, Math.max(x1,x2)+pad, Math.max(y1,y2)+pad],
     L:       [x1, y1, x2, y2],
     LE:      [PDFName.of('None'), PDFName.of('OpenArrow')],
-    BS:      pdfPage.doc.context.obj({ W: w }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addSquareAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
+function _addSquareAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
@@ -235,14 +231,14 @@ function _addSquareAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: numb
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Square'),
     Rect:    [Math.min(x1,x2), Math.min(y1,y2), Math.max(x1,x2), Math.max(y1,y2)],
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness / scale }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
+function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
@@ -250,7 +246,7 @@ function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: numb
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Circle'),
     Rect:    [Math.min(x1,x2), Math.min(y1,y2), Math.max(x1,x2), Math.max(y1,y2)],
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness / scale }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });

--- a/src/renderer/saver.ts
+++ b/src/renderer/saver.ts
@@ -61,16 +61,17 @@ export async function embedAnnotations(pdfBytes: Uint8Array, annotations: Annota
 
     const { width: pdfW, height: pdfH } = await viewer.getPageSize(pageNum);
     const totalRot = viewer.getTotalRotation(pageNum);
+    const scale    = viewer.scale;
 
     for (const ann of pageAnns) {
-      if      (ann.type === 'draw')          _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot);
-      else if (ann.type === 'freeHighlight') _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot);
+      if      (ann.type === 'draw')          _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
+      else if (ann.type === 'freeHighlight') _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
       else if (ann.type === 'highlight')     _addHighlightAnnotation(pdfPage, ann,           pdfW, pdfH, totalRot);
       else if (ann.type === 'text')          _addFreeTextAnnotation (pdfPage, ann,           pdfW, pdfH, totalRot);
-      else if (ann.type === 'line')          _addLineAnnotation     (pdfPage, ann,           pdfW, pdfH, totalRot);
-      else if (ann.type === 'arrow')         _addArrowAnnotation    (pdfPage, ann,           pdfW, pdfH, totalRot);
-      else if (ann.type === 'rect')          _addSquareAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot);
-      else if (ann.type === 'oval')          _addCircleAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot);
+      else if (ann.type === 'line')          _addLineAnnotation     (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
+      else if (ann.type === 'arrow')         _addArrowAnnotation    (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
+      else if (ann.type === 'rect')          _addSquareAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
+      else if (ann.type === 'oval')          _addCircleAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
     }
   }
 
@@ -108,8 +109,9 @@ function hexToRgb01(hex: string): { r: number; g: number; b: number } {
 
 // ── Annotation writers ───────────────────────────────────────
 
-function _addInkAnnotation(pdfPage: PDFPage, ann: DrawAnnotation, pdfW: number, pdfH: number, rot: number): void {
+function _addInkAnnotation(pdfPage: PDFPage, ann: DrawAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
+  const w = ann.thickness / scale; // canvas px → PDF pts
 
   const inkPoints = ann.points.flatMap(([nx, ny]: [number, number]) => {
     const [x, y] = toPdfCoords(nx, ny, pdfW, pdfH, rot);
@@ -121,14 +123,14 @@ function _addInkAnnotation(pdfPage: PDFPage, ann: DrawAnnotation, pdfW: number, 
   const pdfPts = ann.points.map(([nx, ny]: [number, number]) => toPdfCoords(nx, ny, pdfW, pdfH, rot));
   const xs  = pdfPts.map(([x]: [number, number]) => x);
   const ys  = pdfPts.map(([, y]: [number, number]) => y);
-  const pad = ann.thickness;
+  const pad = w;
 
   const annotDict = pdfPage.doc.context.obj({
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Ink'),
     Rect:    [Math.min(...xs) - pad, Math.min(...ys) - pad, Math.max(...xs) + pad, Math.max(...ys) + pad],
     InkList: inkList,
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
+    BS:      pdfPage.doc.context.obj({ W: w }),
     C:       [r, g, b],
     CA:      PDFNumber.of(ann.type === 'freeHighlight' ? 0.4 : 1),
     F:       PDFNumber.of(4),
@@ -188,42 +190,44 @@ function _addFreeTextAnnotation(pdfPage: PDFPage, ann: TextAnnotation, pdfW: num
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addLineAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
+function _addLineAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
-  const pad = ann.thickness;
+  const w   = ann.thickness / scale;
+  const pad = w;
   const annotDict = pdfPage.doc.context.obj({
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Line'),
     Rect:    [Math.min(x1,x2)-pad, Math.min(y1,y2)-pad, Math.max(x1,x2)+pad, Math.max(y1,y2)+pad],
     L:       [x1, y1, x2, y2],
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
+    BS:      pdfPage.doc.context.obj({ W: w }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addArrowAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
+function _addArrowAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
-  const pad = ann.thickness * 5;
+  const w   = ann.thickness / scale;
+  const pad = w * 5;
   const annotDict = pdfPage.doc.context.obj({
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Line'),
     Rect:    [Math.min(x1,x2)-pad, Math.min(y1,y2)-pad, Math.max(x1,x2)+pad, Math.max(y1,y2)+pad],
     L:       [x1, y1, x2, y2],
     LE:      [PDFName.of('None'), PDFName.of('OpenArrow')],
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
+    BS:      pdfPage.doc.context.obj({ W: w }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addSquareAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
+function _addSquareAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
@@ -231,14 +235,14 @@ function _addSquareAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: numb
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Square'),
     Rect:    [Math.min(x1,x2), Math.min(y1,y2), Math.max(x1,x2), Math.max(y1,y2)],
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness / scale }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
+function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
@@ -246,7 +250,7 @@ function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: numb
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Circle'),
     Rect:    [Math.min(x1,x2), Math.min(y1,y2), Math.max(x1,x2), Math.max(y1,y2)],
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness / scale }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });

--- a/src/renderer/viewer.ts
+++ b/src/renderer/viewer.ts
@@ -64,7 +64,7 @@ export class PDFViewer {
     this._annCache         = {}; // pageNum → cached annotation array
     this._pendingRender    = new Set(); // pageNums needing re-render once visible
     this._io               = null;  // IntersectionObserver for deferred renders
-    this._pageSizeCache    = {}; // pageNum → { width, height } in PDF pts — survives sleep
+    this._pageSizeCache    = {}; // pageNum → { width, height } in native (unrotated) PDF pts — survives sleep
     this.isSleeping        = false;
   }
 
@@ -232,12 +232,12 @@ export class PDFViewer {
     return page.getViewport({ scale: this.scale, rotation });
   }
 
-  // Returns { width, height } of the unscaled PDF page in PDF pts (no user rotation).
+  // Returns { width, height } of the unscaled PDF page in native PDF pts (no rotation).
   // Results are cached so this works even while the viewer is sleeping (pdfDoc is null).
   async getPageSize(pageNum: number): Promise<{ width: number; height: number }> {
     if (this._pageSizeCache[pageNum]) return this._pageSizeCache[pageNum];
     const page = await this.pdfDoc!.getPage(pageNum);
-    const vp   = page.getViewport({ scale: 1.0 });
+    const vp   = page.getViewport({ scale: 1.0, rotation: 0 });
     const size = { width: vp.width, height: vp.height };
     this._pageSizeCache[pageNum] = size;
     return size;
@@ -367,9 +367,9 @@ export class PDFViewer {
     const userRot  = this.pageRotations[pageNum] || 0;
     this.pageBaseRotations[pageNum] = page.rotate;
 
-    // Cache unscaled page size so getPageSize() works while sleeping.
+    // Cache unscaled native page size so getPageSize() works while sleeping.
     if (!this._pageSizeCache[pageNum]) {
-      const vp1 = page.getViewport({ scale: 1.0 });
+      const vp1 = page.getViewport({ scale: 1.0, rotation: 0 });
       this._pageSizeCache[pageNum] = { width: vp1.width, height: vp1.height };
     }
 
@@ -416,7 +416,7 @@ export class PDFViewer {
 
     // Populate the page-size cache on every render (cheap: page object is already fetched).
     if (!this._pageSizeCache[pageNum]) {
-      const vp1 = page.getViewport({ scale: 1.0 });
+      const vp1 = page.getViewport({ scale: 1.0, rotation: 0 });
       this._pageSizeCache[pageNum] = { width: vp1.width, height: vp1.height };
     }
 


### PR DESCRIPTION
## Summary

### Fix 1 — Annotation coordinates wrong on rotated pages

- `_pageSizeCache` was populated using `page.getViewport({ scale: 1.0 })` which applies the page's `/Rotate` by default, causing swapped width/height for 90°/270° pages. All three cache sites now pass `rotation: 0` to store native unrotated dimensions.
- The `rot=90` and `rot=270` cases in `toPdfCoords` were each other's correct formula — the case labels were swapped. `rot=0` and `rot=180` were already correct.

### Fix 2 — Annotation thickness changes on zoom and after save/reopen

`ann.thickness` was stored in canvas pixels, which are proportional to `viewer.scale` (Reamlet auto-fits to window width on every open). This caused two problems:

- **During session**: zooming changed the annotator redraw's `ctx.lineWidth` since the canvas resizes but the stored pixel count stays fixed — strokes grow thinner zoomed in and blobbier zoomed out.
- **After save/reopen**: PDF.js multiplies `BS.W` by scale when rendering, making strokes `viewer.scale×` thicker than drawn.

Fix: divide by `viewer.scale` at annotation storage time (producing PDF points), multiply by `viewer.scale` at canvas render time. `BS.W` in saver.ts then receives the value already in PDF points with no further conversion.

Affects: draw, freeHighlight, line, arrow, rect, oval.

Closes #47

## Test plan

- [x] Open a PDF, annotate at fit-to-width zoom, then zoom in and out — strokes stay the same visual weight
- [x] Annotate, save, reopen — strokes match the original thickness
- [x] Open a PDF with built-in `/Rotate: 90`, annotate, save, reopen — correct position and thickness
- [x] Apply user rotation (90°, 270°), annotate, save, reopen — correct position and thickness
- [x] Verify R=0° and R=180° still work correctly