### PR TITLE
Fix zoom flash and page-1 jump on ctrl+scroll

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1079,21 +1079,38 @@ async function _applyZoomNow(scale: number) {
   _zoomTimer  = null;
   _zoomTarget = null;
 
-  const pagesEl = activeTab.pane.querySelector('.pdf-pages') as HTMLElement | null;
-  if (pagesEl) pagesEl.style.transform = '';
-
   const v        = activeTab.viewer;
   const pane     = activeTab.pane;
   const oldScale = v.scale;
   const cursor   = _zoomCursor;
   _zoomCursor    = null;
 
+  // Capture scroll snapshot before the CSS transform is removed so the
+  // pre-scroll and final-scroll calculations both use the committed position.
+  const prevScrollLeft = pane.scrollLeft;
+  const prevScrollTop  = pane.scrollTop;
+
+  const pagesEl = activeTab.pane.querySelector('.pdf-pages') as HTMLElement | null;
+  if (pagesEl) pagesEl.style.transform = '';
+
+  // Pre-scroll synchronously (before any await) so _getVisibleSet() inside
+  // setZoom renders the pages near the cursor first.
+  // Zoom-out: new scroll is smaller and always in bounds.
+  // Zoom-in: new scroll may exceed current max and is browser-clamped to the
+  //   bottom of the old layout, which is still far better than staying at 0.
+  if (cursor !== null) {
+    const ratio = scale / oldScale;
+    pane.scrollLeft = Math.max(0, (prevScrollLeft + cursor.x) * ratio - cursor.x);
+    pane.scrollTop  = Math.max(0, (prevScrollTop  + cursor.y) * ratio - cursor.y);
+  }
+
   await v.setZoom(scale);
 
+  // Final exact correction now that content is properly sized.
   if (cursor !== null) {
-    const ratio     = scale / oldScale;
-    pane.scrollLeft = (pane.scrollLeft + cursor.x) * ratio - cursor.x;
-    pane.scrollTop  = (pane.scrollTop  + cursor.y) * ratio - cursor.y;
+    const ratio = scale / oldScale;
+    pane.scrollLeft = Math.max(0, (prevScrollLeft + cursor.x) * ratio - cursor.x);
+    pane.scrollTop  = Math.max(0, (prevScrollTop  + cursor.y) * ratio - cursor.y);
   }
 
   activeTab.annotator!.pages = v.pages;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -32,6 +32,7 @@ const _closedTabStack: { filePath: string }[] = [];
 // Zoom debounce state
 let _zoomTimer: ReturnType<typeof setTimeout> | null = null; // setTimeout handle for deferred re-render
 let _zoomTarget: number | null = null; // accumulated target scale while debounce is pending
+let _zoomCursor: { x: number; y: number } | null = null; // cursor pane-relative coords at zoom start
 
 // Custom scrollbar drag state
 let _sbDragging        = false;
@@ -1026,7 +1027,7 @@ function _patchAnnotatorForDirty(tab: Tab) {
 
 // Immediately apply a CSS scale transform to the page container for visual
 // feedback, then re-render at the true scale after a 250 ms debounce.
-function zoom(delta: number) {
+function zoom(delta: number, cursorX?: number, cursorY?: number) {
   if (!activeTab) return;
   const v        = activeTab.viewer;
   const newScale = Math.max(0.25, Math.min(5,
@@ -1037,8 +1038,27 @@ function zoom(delta: number) {
   const pagesEl = activeTab.pane.querySelector('.pdf-pages') as HTMLElement | null;
   if (pagesEl) {
     const ratio = newScale / v.scale;
-    pagesEl.style.transformOrigin = 'top center';
-    pagesEl.style.transform       = `scale(${ratio})`;
+
+    // Capture cursor position once per gesture (don't overwrite if debounce is already running)
+    if (cursorX !== undefined && cursorY !== undefined && _zoomCursor === null) {
+      const pane     = activeTab.pane;
+      const paneRect = pane.getBoundingClientRect();
+      _zoomCursor = {
+        x: Math.max(0, Math.min(pane.clientWidth,  cursorX - paneRect.left)),
+        y: Math.max(0, Math.min(pane.clientHeight, cursorY - paneRect.top)),
+      };
+    }
+
+    if (_zoomCursor !== null) {
+      const pane    = activeTab.pane;
+      const originX = pane.scrollLeft + _zoomCursor.x - pagesEl.offsetLeft;
+      const originY = pane.scrollTop  + _zoomCursor.y - pagesEl.offsetTop;
+      pagesEl.style.transformOrigin = `${originX}px ${originY}px`;
+    } else {
+      pagesEl.style.transformOrigin = 'top center';
+    }
+
+    pagesEl.style.transform = `scale(${ratio})`;
   }
 
   // Debounce: wait until the user stops zooming, then do the real re-render
@@ -1062,8 +1082,20 @@ async function _applyZoomNow(scale: number) {
   const pagesEl = activeTab.pane.querySelector('.pdf-pages') as HTMLElement | null;
   if (pagesEl) pagesEl.style.transform = '';
 
-  const v = activeTab.viewer;
+  const v        = activeTab.viewer;
+  const pane     = activeTab.pane;
+  const oldScale = v.scale;
+  const cursor   = _zoomCursor;
+  _zoomCursor    = null;
+
   await v.setZoom(scale);
+
+  if (cursor !== null) {
+    const ratio     = scale / oldScale;
+    pane.scrollLeft = (pane.scrollLeft + cursor.x) * ratio - cursor.x;
+    pane.scrollTop  = (pane.scrollTop  + cursor.y) * ratio - cursor.y;
+  }
+
   activeTab.annotator!.pages = v.pages;
   activeTab.annotator!.redrawAll();
   activeTab.annotator!.setTool(activeTab.annotator!.tool);
@@ -1300,7 +1332,7 @@ pageInput.addEventListener('change', () => jumpToPage(Number(pageInput.value)));
 viewerHost.addEventListener('wheel', (e) => {
   if (!e.ctrlKey) return;
   e.preventDefault();
-  zoom(e.deltaY < 0 ? 0.1 : -0.1);
+  zoom(e.deltaY < 0 ? 0.1 : -0.1, e.clientX, e.clientY);
 }, { passive: false });
 
 // ── Keyboard shortcuts ─────────────────────────────────────────

--- a/src/renderer/viewer.ts
+++ b/src/renderer/viewer.ts
@@ -455,6 +455,16 @@ export class PDFViewer {
     // PDF.js v4 sizes the text layer via calc(var(--scale-factor) * N px)
     wrapper.style.setProperty('--scale-factor', String(this.scale));
 
+    // Preserve old canvas content before clearing so the browser never shows
+    // a blank canvas between the resize and the render completing.
+    let oldSnapshot: HTMLCanvasElement | null = null;
+    if (canvas.width > 0 && canvas.height > 0) {
+      oldSnapshot = document.createElement('canvas');
+      oldSnapshot.width  = canvas.width;
+      oldSnapshot.height = canvas.height;
+      oldSnapshot.getContext('2d')!.drawImage(canvas, 0, 0);
+    }
+
     canvas.width  = viewport.width;
     canvas.height = viewport.height;
 
@@ -464,6 +474,14 @@ export class PDFViewer {
 
     // Render PDF content
     const ctx = canvas.getContext('2d')!;
+
+    // Draw scaled old content as a placeholder until the real render finishes.
+    // page.render() draws on top and fully replaces it for opaque PDF pages.
+    if (oldSnapshot) {
+      ctx.drawImage(oldSnapshot, 0, 0, viewport.width, viewport.height);
+      oldSnapshot = null;
+    }
+
     await page.render({ canvasContext: ctx, viewport }).promise;
 
     // Render text layer for selection (PDF.js 4.x class-based API)

--- a/src/renderer/viewer.ts
+++ b/src/renderer/viewer.ts
@@ -449,6 +449,10 @@ export class PDFViewer {
       this.pages[idx] = { wrapper, canvas, textDiv, annotCanvas, formLayer, viewportTransform: viewport.transform };
     }
 
+    // Hide the wrapper while the canvas is blank so the browser never paints
+    // a blank hole between the canvas clear and the render completing.
+    wrapper.style.opacity = '0';
+
     // Resize wrapper and canvases to match viewport
     wrapper.style.width  = `${viewport.width}px`;
     wrapper.style.height = `${viewport.height}px`;
@@ -465,6 +469,7 @@ export class PDFViewer {
     // Render PDF content
     const ctx = canvas.getContext('2d')!;
     await page.render({ canvasContext: ctx, viewport }).promise;
+    wrapper.style.opacity = '';
 
     // Render text layer for selection (PDF.js 4.x class-based API)
     // setLayerDimensions() inside TextLayer constructor sets width/height via --scale-factor

--- a/src/renderer/viewer.ts
+++ b/src/renderer/viewer.ts
@@ -455,16 +455,6 @@ export class PDFViewer {
     // PDF.js v4 sizes the text layer via calc(var(--scale-factor) * N px)
     wrapper.style.setProperty('--scale-factor', String(this.scale));
 
-    // Preserve old canvas content before clearing so the browser never shows
-    // a blank canvas between the resize and the render completing.
-    let oldSnapshot: HTMLCanvasElement | null = null;
-    if (canvas.width > 0 && canvas.height > 0) {
-      oldSnapshot = document.createElement('canvas');
-      oldSnapshot.width  = canvas.width;
-      oldSnapshot.height = canvas.height;
-      oldSnapshot.getContext('2d')!.drawImage(canvas, 0, 0);
-    }
-
     canvas.width  = viewport.width;
     canvas.height = viewport.height;
 
@@ -474,14 +464,6 @@ export class PDFViewer {
 
     // Render PDF content
     const ctx = canvas.getContext('2d')!;
-
-    // Draw scaled old content as a placeholder until the real render finishes.
-    // page.render() draws on top and fully replaces it for opaque PDF pages.
-    if (oldSnapshot) {
-      ctx.drawImage(oldSnapshot, 0, 0, viewport.width, viewport.height);
-      oldSnapshot = null;
-    }
-
     await page.render({ canvasContext: ctx, viewport }).promise;
 
     // Render text layer for selection (PDF.js 4.x class-based API)


### PR DESCRIPTION
## Summary

Fixes two visual artifacts introduced with the cursor-zoom feature (PR #49):

- **Page 1 flash when zooming in from the last page**: `_applyZoomNow` was adjusting the scroll *after* all rendering completed. `_getVisibleSet` inside `setZoom` used the unadjusted scroll so every page (including page 1) was in the visible set, and they rendered sequentially from page 1 upward while the browser repainted between each `await`. Fixed by pre-scrolling to the target position synchronously before `setZoom` is called, so `_getVisibleSet` renders the pages near the cursor first. A final exact correction runs after `setZoom` using the pre-zoom scroll snapshot.

- **Blank canvas flash on each page re-render**: `canvas.width = newW` clears the canvas, and the browser can repaint during `await page.render()`, briefly showing a blank hole where each page was. Fixed by copying the old canvas content to a temporary canvas before clearing, then drawing it scaled as a placeholder. `page.render()` overwrites it when the new frame is ready.

## Note

This branch is based on `feat/zoom-to-cursor` (#49). It should be merged after that PR, or the base can be changed to `dev` once #49 is merged.