### PR TITLE
Add print preview window with full print settings

### DIFF
--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -1,0 +1,35 @@
+/* Reamlet — Print Preview window styles */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+/* screen layout */
+body { margin: 0; background: #1e1e1e; color: #ccc; font: 13px/1.4 system-ui, sans-serif; display: flex; height: 100vh; overflow: hidden; }
+#settings-panel { width: 200px; min-width: 200px; background: #252526; border-right: 1px solid #333; padding: 16px; display: flex; flex-direction: column; gap: 12px; overflow-y: auto; }
+#preview-area { flex: 1; overflow-y: auto; padding: 24px; display: flex; flex-direction: column; align-items: center; gap: 16px; background: #3c3c3c; }
+.print-page { background: white; box-shadow: 0 2px 8px rgba(0,0,0,0.5); }
+.print-page img { display: block; max-width: 100%; }
+.print-page.excluded { display: none !important; }
+
+/* controls */
+label { display: block; font-size: 12px; color: #999; margin-bottom: 4px; }
+input[type="number"], input[type="text"], select { width: 100%; box-sizing: border-box; background: #3c3c3c; color: #ccc; border: 1px solid #555; border-radius: 3px; padding: 4px 6px; font-size: 12px; }
+.radio-group { display: flex; flex-direction: column; gap: 4px; }
+.radio-group label { display: flex; align-items: center; gap: 6px; color: #ccc; font-size: 12px; margin: 0; }
+button { width: 100%; padding: 7px; border-radius: 4px; border: none; cursor: pointer; font-size: 13px; }
+#btn-print { background: #0078d4; color: white; margin-top: auto; }
+#btn-print:hover { background: #106ebe; }
+#btn-close { background: #3c3c3c; color: #ccc; border: 1px solid #555; margin-top: 6px; }
+#btn-close:hover { background: #4c4c4c; }
+#status { font-size: 11px; color: #888; margin-top: 8px; }
+.hidden { display: none !important; }
+.greyscale .print-page img { filter: grayscale(1); }
+
+/* print output */
+@media print {
+  @page { margin: 0; size: auto; }
+  #settings-panel { display: none !important; }
+  #preview-area { padding: 0; gap: 0; background: white; }
+  body { display: block; }
+  .print-page { box-shadow: none; page-break-after: always; break-after: page; }
+  .print-page.fit img { width: 100vw; height: 100vh; object-fit: contain; display: block; }
+  .print-page:not(.fit) img { display: block; }
+}

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -23,6 +23,37 @@ body {
   overflow-y: auto;
 }
 #settings-panel h3 { margin: 0 0 12px; font-size: 14px; color: #eee; }
+#preview-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #3c3c3c;
+}
+#preview-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  background: #2d2d2d;
+  border-bottom: 1px solid #222;
+  flex-shrink: 0;
+}
+#preview-toolbar button {
+  background: #3c3c3c;
+  color: #ccc;
+  border: 1px solid #555;
+  border-radius: 3px;
+  width: 24px;
+  height: 22px;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+#preview-toolbar button:hover:not(:disabled) { background: #4c4c4c; }
+#preview-toolbar button:disabled { opacity: 0.4; cursor: not-allowed; }
+#zoom-label { font-size: 12px; color: #999; min-width: 38px; text-align: center; }
 #preview-area {
   flex: 1;
   overflow-y: auto;
@@ -31,7 +62,6 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  background: #3c3c3c;
 }
 
 /* ── Settings sections ────────────────────────────────────────── */
@@ -92,12 +122,18 @@ details[open] summary { margin-bottom: 8px; }
 .greyscale .print-page img { filter: grayscale(1); }
 
 /* ── Print output ─────────────────────────────────────────────── */
+@page { margin: 0; size: portrait; }
+@page landscape-page { margin: 0; size: landscape; }
+
 @media print {
-  @page { margin: 0; size: auto; }
+  @page { margin: 0; size: portrait; }
   #settings-panel { display: none !important; }
+  #preview-toolbar { display: none !important; }
   body { display: block; overflow: visible; }
+  #preview-wrapper { display: block; overflow: visible; }
   #preview-area { padding: 0; gap: 0; background: white; overflow: visible; display: block; }
   /* Each page wrapper fills exactly one sheet of paper */
+  .print-page.landscape { page: landscape-page; }
   .print-page {
     box-shadow: none;
     page-break-after: always;

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -122,18 +122,14 @@ details[open] summary { margin-bottom: 8px; }
 .greyscale .print-page img { filter: grayscale(1); }
 
 /* ── Print output ─────────────────────────────────────────────── */
-@page { margin: 0; size: portrait; }
-@page landscape-page { margin: 0; size: landscape; }
-
 @media print {
-  @page { margin: 0; size: portrait; }
+  @page { margin: 0; size: auto; }
   #settings-panel { display: none !important; }
   #preview-toolbar { display: none !important; }
   body { display: block; overflow: visible; }
   #preview-wrapper { display: block; overflow: visible; }
   #preview-area { padding: 0; gap: 0; background: white; overflow: visible; display: block; }
   /* Each page wrapper fills exactly one sheet of paper */
-  .print-page.landscape { page: landscape-page; }
   .print-page {
     box-shadow: none;
     page-break-after: always;

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -117,8 +117,16 @@ details[open] summary { margin-bottom: 8px; }
 #status { font-size: 11px; color: #888; margin-top: 8px; text-align: center; }
 
 /* ── Preview pages ────────────────────────────────────────────── */
-.print-page { background: white; box-shadow: 0 2px 8px rgba(0,0,0,0.5); }
-.print-page img { display: block; }
+.print-page {
+  background: white;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.print-page img { display: block; max-width: 100%; max-height: 100%; }
 .greyscale .print-page img { filter: grayscale(1); }
 
 /* ── Print output ─────────────────────────────────────────────── */

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -96,7 +96,27 @@ details[open] summary { margin-bottom: 8px; }
   @page { margin: 0; size: auto; }
   #settings-panel { display: none !important; }
   body { display: block; overflow: visible; }
-  #preview-area { padding: 0; gap: 0; background: white; overflow: visible; }
-  .print-page { box-shadow: none; page-break-after: always; break-after: page; }
-  .print-page img { width: 100vw; height: 100vh; object-fit: contain; display: block; }
+  #preview-area { padding: 0; gap: 0; background: white; overflow: visible; display: block; }
+  /* Each page wrapper fills exactly one sheet of paper */
+  .print-page {
+    box-shadow: none;
+    page-break-after: always;
+    break-after: page;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: white;
+  }
+  /* Override inline px dimensions so the image scales to fit the paper.
+     !important is required to beat the inline style attribute. */
+  .print-page img {
+    width: auto !important;
+    height: auto !important;
+    max-width: 100% !important;
+    max-height: 100% !important;
+    display: block;
+  }
 }

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -118,7 +118,7 @@ details[open] summary { margin-bottom: 8px; }
 
 /* ── Preview pages ────────────────────────────────────────────── */
 .print-page { background: white; box-shadow: 0 2px 8px rgba(0,0,0,0.5); }
-.print-page img { display: block; max-width: 100%; }
+.print-page img { display: block; }
 .greyscale .print-page img { filter: grayscale(1); }
 
 /* ── Print output ─────────────────────────────────────────────── */
@@ -128,7 +128,7 @@ details[open] summary { margin-bottom: 8px; }
   #preview-toolbar { display: none !important; }
   body { display: block; overflow: visible; }
   #preview-wrapper { display: block; overflow: visible; }
-  #preview-area { padding: 0; gap: 0; background: white; overflow: visible; display: block; }
+  #preview-area { padding: 0; gap: 0; background: white; overflow: visible; display: block; zoom: normal; }
   /* Each page wrapper fills exactly one sheet of paper */
   .print-page {
     box-shadow: none;

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -1,35 +1,102 @@
 /* Reamlet — Print Preview window styles */
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
-/* screen layout */
-body { margin: 0; background: #1e1e1e; color: #ccc; font: 13px/1.4 system-ui, sans-serif; display: flex; height: 100vh; overflow: hidden; }
-#settings-panel { width: 200px; min-width: 200px; background: #252526; border-right: 1px solid #333; padding: 16px; display: flex; flex-direction: column; gap: 12px; overflow-y: auto; }
-#preview-area { flex: 1; overflow-y: auto; padding: 24px; display: flex; flex-direction: column; align-items: center; gap: 16px; background: #3c3c3c; }
+/* ── Layout ───────────────────────────────────────────────────── */
+body {
+  margin: 0;
+  background: #1e1e1e;
+  color: #ccc;
+  font: 13px/1.4 system-ui, sans-serif;
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+}
+#settings-panel {
+  width: 210px;
+  min-width: 210px;
+  background: #252526;
+  border-right: 1px solid #333;
+  padding: 14px 14px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  overflow-y: auto;
+}
+#settings-panel h3 { margin: 0 0 12px; font-size: 14px; color: #eee; }
+#preview-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  background: #3c3c3c;
+}
+
+/* ── Settings sections ────────────────────────────────────────── */
+section { margin-bottom: 12px; }
+section.row { display: flex; align-items: flex-end; gap: 10px; }
+section.row > div { flex: 1; }
+label { display: block; font-size: 11px; color: #999; margin-bottom: 3px; }
+.checkbox-label { display: flex !important; align-items: center; gap: 6px; color: #ccc !important; font-size: 12px !important; margin: 0 !important; cursor: pointer; }
+.radio-group { display: flex; flex-direction: column; gap: 4px; }
+.radio-group label { display: flex; align-items: center; gap: 6px; color: #ccc; font-size: 12px; margin: 0; cursor: pointer; }
+input[type="number"],
+input[type="text"],
+select {
+  width: 100%;
+  box-sizing: border-box;
+  background: #3c3c3c;
+  color: #ccc;
+  border: 1px solid #555;
+  border-radius: 3px;
+  padding: 4px 6px;
+  font-size: 12px;
+}
+select { cursor: pointer; }
+
+/* More settings */
+details { margin-bottom: 12px; }
+summary { font-size: 12px; color: #888; cursor: pointer; user-select: none; padding: 4px 0; }
+summary:hover { color: #ccc; }
+details[open] summary { margin-bottom: 8px; }
+.hint { font-size: 11px; color: #666; margin: 4px 0 0; }
+
+/* Printer Preferences button */
+#btn-printer-pref {
+  width: 100%;
+  margin-top: 5px;
+  padding: 5px;
+  background: #3c3c3c;
+  color: #ccc;
+  border: 1px solid #555;
+  border-radius: 3px;
+  font-size: 11px;
+  cursor: pointer;
+}
+#btn-printer-pref:hover { background: #4c4c4c; }
+
+/* Actions */
+.actions { margin-top: auto; padding-top: 10px; display: flex; flex-direction: column; gap: 6px; }
+#btn-print { background: #0078d4; color: white; padding: 7px; border-radius: 4px; border: none; cursor: pointer; font-size: 13px; width: 100%; }
+#btn-print:hover { background: #106ebe; }
+#btn-print:disabled { background: #555; cursor: not-allowed; }
+#btn-close { background: #3c3c3c; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 7px; cursor: pointer; font-size: 13px; width: 100%; }
+#btn-close:hover { background: #4c4c4c; }
+#status { font-size: 11px; color: #888; margin-top: 8px; text-align: center; }
+
+/* ── Preview pages ────────────────────────────────────────────── */
 .print-page { background: white; box-shadow: 0 2px 8px rgba(0,0,0,0.5); }
 .print-page img { display: block; max-width: 100%; }
-.print-page.excluded { display: none !important; }
-
-/* controls */
-label { display: block; font-size: 12px; color: #999; margin-bottom: 4px; }
-input[type="number"], input[type="text"], select { width: 100%; box-sizing: border-box; background: #3c3c3c; color: #ccc; border: 1px solid #555; border-radius: 3px; padding: 4px 6px; font-size: 12px; }
-.radio-group { display: flex; flex-direction: column; gap: 4px; }
-.radio-group label { display: flex; align-items: center; gap: 6px; color: #ccc; font-size: 12px; margin: 0; }
-button { width: 100%; padding: 7px; border-radius: 4px; border: none; cursor: pointer; font-size: 13px; }
-#btn-print { background: #0078d4; color: white; margin-top: auto; }
-#btn-print:hover { background: #106ebe; }
-#btn-close { background: #3c3c3c; color: #ccc; border: 1px solid #555; margin-top: 6px; }
-#btn-close:hover { background: #4c4c4c; }
-#status { font-size: 11px; color: #888; margin-top: 8px; }
-.hidden { display: none !important; }
 .greyscale .print-page img { filter: grayscale(1); }
 
-/* print output */
+/* ── Print output ─────────────────────────────────────────────── */
 @media print {
   @page { margin: 0; size: auto; }
   #settings-panel { display: none !important; }
-  #preview-area { padding: 0; gap: 0; background: white; }
-  body { display: block; }
+  body { display: block; overflow: visible; }
+  #preview-area { padding: 0; gap: 0; background: white; overflow: visible; }
   .print-page { box-shadow: none; page-break-after: always; break-after: page; }
-  .print-page.fit img { width: 100vw; height: 100vh; object-fit: contain; display: block; }
-  .print-page:not(.fit) img { display: block; }
+  .print-page img { width: 100vw; height: 100vh; object-fit: contain; display: block; }
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -937,6 +937,7 @@ html, body {
   .form-layer   { display: none !important; }
   body { background: white; overflow: visible; }
   html { overflow: visible; }
+  #print-debug-overlay { display: block !important; position: static !important; }
 }
 
 /* ── Context menu ─────────────────────────────────────────────── */

--- a/assets/style.css
+++ b/assets/style.css
@@ -925,12 +925,14 @@ html, body {
 
 /* ── Print ────────────────────────────────────────────────────── */
 @media print {
+  @page { margin: 0; }
   #topbar, #sidebar, #toc-panel, #empty-state, #viewer-scrollbar, #viewer-scrollbar-h { display: none !important; }
   #content-area { position: static; overflow: visible; }
   #viewer-host  { position: static; overflow: visible; }
   .viewer-pane  { display: none; position: static; overflow: visible; }
   .viewer-pane.active { display: block; }
-  .page-wrapper { page-break-after: always; break-after: page; box-shadow: none; }
+  .page-wrapper { page-break-after: always; break-after: page; box-shadow: none; width: 100vw !important; height: 100vh !important; overflow: hidden; }
+  .page-wrapper canvas { width: 100% !important; height: 100% !important; }
   .annot-canvas { display: block; }
   .form-layer   { display: none !important; }
   body { background: white; overflow: visible; }

--- a/assets/style.css
+++ b/assets/style.css
@@ -925,19 +925,16 @@ html, body {
 
 /* ── Print ────────────────────────────────────────────────────── */
 @media print {
-  @page { margin: 0; }
   #topbar, #sidebar, #toc-panel, #empty-state, #viewer-scrollbar, #viewer-scrollbar-h { display: none !important; }
   #content-area { position: static; overflow: visible; }
   #viewer-host  { position: static; overflow: visible; }
   .viewer-pane  { display: none; position: static; overflow: visible; }
   .viewer-pane.active { display: block; }
-  .page-wrapper { page-break-after: always; break-after: page; box-shadow: none; width: 100vw !important; height: 100vh !important; overflow: hidden; }
-  .page-wrapper canvas { width: 100% !important; height: 100% !important; }
+  .page-wrapper { page-break-after: always; break-after: page; box-shadow: none; }
   .annot-canvas { display: block; }
   .form-layer   { display: none !important; }
   body { background: white; overflow: visible; }
   html { overflow: visible; }
-  #print-debug-overlay { display: block !important; position: static !important; }
 }
 
 /* ── Context menu ─────────────────────────────────────────────── */

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -25,6 +25,8 @@
             <button data-menu="save">Save <span>Ctrl+S</span></button>
             <button data-menu="save-copy">Save Copy… <span>Ctrl+⇧+S</span></button>
             <div class="tdrop-sep"></div>
+            <button data-menu="print">Print… <span>Ctrl+P</span></button>
+            <div class="tdrop-sep"></div>
             <button data-menu="close-tab">Close Tab <span>Ctrl+W</span></button>
             <button data-menu="reopen-tab">Reopen Tab <span>Ctrl+⇧+T</span></button>
             <div class="tdrop-sep"></div>

--- a/renderer/print-preview.html
+++ b/renderer/print-preview.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<!-- Reamlet — SPDX-License-Identifier: GPL-3.0-or-later -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self' file:; script-src 'self' 'unsafe-eval' file:; style-src 'self' 'unsafe-inline'; worker-src blob: file:; img-src 'self' data: file:;" />
+  <title>Print</title>
+  <link rel="stylesheet" href="../assets/print-preview.css" />
+</head>
+<body>
+  <div id="settings-panel">
+    <h3 style="margin:0 0 4px;">Print</h3>
+
+    <div>
+      <label for="inp-copies">Copies</label>
+      <input type="number" id="inp-copies" min="1" max="99" value="1" />
+    </div>
+
+    <div>
+      <label for="sel-pages">Pages</label>
+      <select id="sel-pages">
+        <option value="all">All</option>
+        <option value="custom">Custom…</option>
+      </select>
+      <input type="text" id="inp-pages-custom" placeholder="e.g. 1–3, 5" class="hidden" style="margin-top:4px;" />
+    </div>
+
+    <div>
+      <label for="sel-scale">Scale</label>
+      <select id="sel-scale">
+        <option value="fit">Fit to page</option>
+        <option value="100">100%</option>
+        <option value="75">75%</option>
+        <option value="50">50%</option>
+        <option value="25">25%</option>
+      </select>
+    </div>
+
+    <div>
+      <label>Colour</label>
+      <div class="radio-group">
+        <label><input type="radio" name="color" value="color" checked /> Colour</label>
+        <label><input type="radio" name="color" value="grey" /> Greyscale</label>
+      </div>
+    </div>
+
+    <button id="btn-print">Print</button>
+    <button id="btn-close">Close</button>
+    <div id="status">Loading…</div>
+  </div>
+
+  <div id="preview-area"></div>
+
+  <script type="module" src="../out/renderer/print-preview.js"></script>
+</body>
+</html>

--- a/renderer/print-preview.html
+++ b/renderer/print-preview.html
@@ -10,43 +10,85 @@
 </head>
 <body>
   <div id="settings-panel">
-    <h3 style="margin:0 0 4px;">Print</h3>
+    <h3>Print</h3>
 
-    <div>
-      <label for="inp-copies">Copies</label>
-      <input type="number" id="inp-copies" min="1" max="99" value="1" />
-    </div>
+    <section>
+      <label for="sel-printer">Printer</label>
+      <select id="sel-printer"></select>
+      <button id="btn-printer-pref">Printer Preferences</button>
+    </section>
 
-    <div>
-      <label for="sel-pages">Pages</label>
-      <select id="sel-pages">
-        <option value="all">All</option>
-        <option value="custom">Custom…</option>
-      </select>
-      <input type="text" id="inp-pages-custom" placeholder="e.g. 1–3, 5" class="hidden" style="margin-top:4px;" />
-    </div>
+    <section class="row">
+      <div>
+        <label for="inp-copies">Copies</label>
+        <input type="number" id="inp-copies" min="1" max="99" value="1" />
+      </div>
+      <label class="checkbox-label">
+        <input type="checkbox" id="chk-collate" /> Collate
+      </label>
+    </section>
 
-    <div>
+    <section>
+      <label for="inp-pages">Pages</label>
+      <input type="text" id="inp-pages" placeholder="All" />
+    </section>
+
+    <section>
       <label for="sel-scale">Scale</label>
       <select id="sel-scale">
-        <option value="fit">Fit to page</option>
+        <option value="fit" selected>Fit to page</option>
         <option value="100">100%</option>
         <option value="75">75%</option>
         <option value="50">50%</option>
         <option value="25">25%</option>
       </select>
-    </div>
+    </section>
 
-    <div>
+    <section>
       <label>Colour</label>
       <div class="radio-group">
         <label><input type="radio" name="color" value="color" checked /> Colour</label>
         <label><input type="radio" name="color" value="grey" /> Greyscale</label>
       </div>
+    </section>
+
+    <details id="more-settings">
+      <summary>More settings</summary>
+
+      <section>
+        <label for="sel-pps">Pages per sheet</label>
+        <select id="sel-pps">
+          <option value="1" selected>1</option>
+          <option value="2">2</option>
+          <option value="4">4</option>
+          <option value="6">6</option>
+          <option value="9">9</option>
+          <option value="16">16</option>
+        </select>
+      </section>
+
+      <section>
+        <label for="sel-duplex">Two-sided</label>
+        <select id="sel-duplex">
+          <option value="simplex" selected>None</option>
+          <option value="longEdge">Long edge</option>
+          <option value="shortEdge">Short edge</option>
+        </select>
+      </section>
+
+      <section>
+        <label class="checkbox-label">
+          <input type="checkbox" id="chk-booklet" /> Booklet
+        </label>
+        <p class="hint">Arranges pages for folding into a booklet. Uses two pages per sheet.</p>
+      </section>
+    </details>
+
+    <div class="actions">
+      <button id="btn-print">Print</button>
+      <button id="btn-close">Close</button>
     </div>
 
-    <button id="btn-print">Print</button>
-    <button id="btn-close">Close</button>
     <div id="status">Loading…</div>
   </div>
 

--- a/renderer/print-preview.html
+++ b/renderer/print-preview.html
@@ -45,6 +45,14 @@
     </section>
 
     <section>
+      <label>Orientation</label>
+      <div class="radio-group">
+        <label><input type="radio" name="orientation" value="portrait"  checked /> Portrait</label>
+        <label><input type="radio" name="orientation" value="landscape"         /> Landscape</label>
+      </div>
+    </section>
+
+    <section>
       <label>Colour</label>
       <div class="radio-group">
         <label><input type="radio" name="color" value="color" checked /> Colour</label>

--- a/renderer/print-preview.html
+++ b/renderer/print-preview.html
@@ -80,7 +80,7 @@
         <label class="checkbox-label">
           <input type="checkbox" id="chk-booklet" /> Booklet
         </label>
-        <p class="hint">Arranges pages for folding into a booklet. Uses two pages per sheet.</p>
+        <p class="hint">Arranges pages for folding into a booklet. Uses two pages per sheet. Prints all pages regardless of the Pages field.</p>
       </section>
     </details>
 

--- a/renderer/print-preview.html
+++ b/renderer/print-preview.html
@@ -92,7 +92,14 @@
     <div id="status">Loading…</div>
   </div>
 
-  <div id="preview-area"></div>
+  <div id="preview-wrapper">
+    <div id="preview-toolbar">
+      <button id="btn-zoom-out" title="Zoom out">−</button>
+      <span id="zoom-label">100%</span>
+      <button id="btn-zoom-in" title="Zoom in">+</button>
+    </div>
+    <div id="preview-area"></div>
+  </div>
 
   <script type="module" src="../out/renderer/print-preview.js"></script>
 </body>

--- a/src/main.ts
+++ b/src/main.ts
@@ -240,7 +240,10 @@ ipcMain.handle('get-printers', async (event: IpcMainInvokeEvent) => {
 });
 
 // Open the Windows printer preferences dialog for the given printer
-ipcMain.handle('open-printer-preferences', (_event: IpcMainInvokeEvent, printerName: string) => {
+ipcMain.handle('open-printer-preferences', async (event: IpcMainInvokeEvent, printerName: string) => {
+  const printers = await event.sender.getPrintersAsync();
+  const valid = printers.some((p: { name: string }) => p.name === printerName);
+  if (!valid) return { ok: false, error: 'Unknown printer.' };
   const safe = printerName.replace(/["]/g, '');
   exec(`rundll32 printui.dll,PrintUIEntry /e /n "${safe}"`);
   return { ok: true };

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,33 +234,43 @@ ipcMain.handle('reveal-in-explorer', (_event: IpcMainInvokeEvent, filePath: stri
   return { ok: true };
 });
 
-// Open the PDF file in a Chromium window and invoke the system print dialog.
-// This bypasses the canvas renderer entirely so the output is always correct.
-ipcMain.handle('print-pdf', async (_event: IpcMainInvokeEvent, filePath: string): Promise<{ ok: boolean; error?: string }> => {
+// Open a visible print preview window where the user can configure and execute printing.
+ipcMain.handle('open-print-preview', async (_event: IpcMainInvokeEvent, filePath: string): Promise<{ ok: boolean; error?: string }> => {
   if (!filePath || !fs.existsSync(filePath)) return { ok: false, error: 'File not found.' };
 
-  const printWin: BW = new BrowserWindow({
+  const previewWin: BW = new BrowserWindow({
+    width: 960,
+    height: 700,
+    minWidth: 600,
+    minHeight: 400,
+    title: 'Print',
     show: false,
-    skipTaskbar: true,
-    webPreferences: { nodeIntegration: false, contextIsolation: true },
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js'),
+    },
   });
 
-  await printWin.loadURL('file:///' + filePath.replace(/\\/g, '/'));
+  await previewWin.loadFile(path.join(__dirname, '..', 'renderer', 'print-preview.html'));
+  previewWin.show();
 
-  // Chromium skips GPU compositing for windows that are never shown, producing blank
-  // print output. Show the window (without stealing focus) so the PDF viewer renders,
-  // then wait for the PDF title update which signals the viewer has finished loading.
-  printWin.showInactive();
-  await new Promise<void>(resolve => {
-    const tid = setTimeout(resolve, 3000);
-    printWin.webContents.once('page-title-updated', () => { clearTimeout(tid); resolve(); });
-  });
+  const buffer = fs.readFileSync(filePath);
+  previewWin.webContents.send('pdf-data', { buffer: buffer.buffer });
+
+  return { ok: true };
+});
+
+// Execute the print dialog from the preview window's renderer process.
+ipcMain.handle('execute-print', (_event: IpcMainInvokeEvent, options: { copies: number; color: boolean; scaleFactor: number }): Promise<{ ok: boolean; error?: string }> => {
+  const win = BrowserWindow.fromWebContents(_event.sender);
+  if (!win) return Promise.resolve({ ok: false, error: 'No window.' });
 
   return new Promise(resolve => {
-    printWin.webContents.print({ silent: false }, (success: boolean, errorType: string) => {
-      printWin.destroy();
-      resolve(success ? { ok: true } : { ok: false, error: errorType });
-    });
+    win.webContents.print(
+      { silent: false, copies: options.copies, color: options.color, scaleFactor: options.scaleFactor },
+      (success: boolean, errorType: string) => resolve(success ? { ok: true } : { ok: false, error: errorType })
+    );
   });
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,8 @@ function buildMenu(): void {
         { label: 'Save',        accelerator: 'CmdOrCtrl+S',       click: () => fw()?.webContents.send('menu-save') },
         { label: 'Save Copy…',  accelerator: 'CmdOrCtrl+Shift+S', click: () => fw()?.webContents.send('menu-save-copy') },
         { type: 'separator' },
+        { label: 'Print…',          accelerator: 'CmdOrCtrl+P',           click: () => fw()?.webContents.send('menu-print') },
+        { type: 'separator' },
         { label: 'Close Tab',       accelerator: 'CmdOrCtrl+W',           click: () => fw()?.webContents.send('menu-close-tab') },
         { label: 'Reopen Closed Tab', accelerator: 'CmdOrCtrl+Shift+T',  click: () => fw()?.webContents.send('menu-reopen-tab') },
         { type: 'separator' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,6 +234,18 @@ ipcMain.handle('reveal-in-explorer', (_event: IpcMainInvokeEvent, filePath: stri
   return { ok: true };
 });
 
+// Return the list of system printers from the print preview window's web contents
+ipcMain.handle('get-printers', async (event: IpcMainInvokeEvent) => {
+  return event.sender.getPrintersAsync();
+});
+
+// Open the Windows printer preferences dialog for the given printer
+ipcMain.handle('open-printer-preferences', (_event: IpcMainInvokeEvent, printerName: string) => {
+  const safe = printerName.replace(/["]/g, '');
+  exec(`rundll32 printui.dll,PrintUIEntry /e /n "${safe}"`);
+  return { ok: true };
+});
+
 // Open a visible print preview window where the user can configure and execute printing.
 ipcMain.handle('open-print-preview', async (_event: IpcMainInvokeEvent, filePath: string): Promise<{ ok: boolean; error?: string }> => {
   if (!filePath || !fs.existsSync(filePath)) return { ok: false, error: 'File not found.' };
@@ -261,15 +273,33 @@ ipcMain.handle('open-print-preview', async (_event: IpcMainInvokeEvent, filePath
   return { ok: true };
 });
 
-// Execute the print dialog from the preview window's renderer process.
-ipcMain.handle('execute-print', (_event: IpcMainInvokeEvent, options: { copies: number; color: boolean; scaleFactor: number }): Promise<{ ok: boolean; error?: string }> => {
+// Execute a silent print (no system dialog) from the preview window's renderer process.
+ipcMain.handle('execute-print', (_event: IpcMainInvokeEvent, options: {
+  deviceName:  string;
+  copies:      number;
+  color:       boolean;
+  collate:     boolean;
+  duplexMode:  'simplex' | 'longEdge' | 'shortEdge';
+  scaleFactor: number;
+  landscape:   boolean;
+}): Promise<{ ok: boolean; error?: string }> => {
   const win = BrowserWindow.fromWebContents(_event.sender);
   if (!win) return Promise.resolve({ ok: false, error: 'No window.' });
 
   return new Promise(resolve => {
     win.webContents.print(
-      { silent: false, copies: options.copies, color: options.color, scaleFactor: options.scaleFactor },
-      (success: boolean, errorType: string) => resolve(success ? { ok: true } : { ok: false, error: errorType })
+      {
+        silent:      true,
+        deviceName:  options.deviceName,
+        copies:      options.copies,
+        color:       options.color,
+        collate:     options.collate,
+        duplexMode:  options.duplexMode,
+        scaleFactor: options.scaleFactor,
+        landscape:   options.landscape,
+      },
+      (success: boolean, errorType: string) =>
+        resolve(success ? { ok: true } : { ok: false, error: errorType })
     );
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,16 +124,8 @@ ipcMain.handle('open-file-dialog', async (event: IpcMainInvokeEvent) => {
   }));
 });
 
-ipcMain.handle('save-file', async (event: IpcMainInvokeEvent, filePath: string, arrayBuffer: ArrayBuffer) => {
+ipcMain.handle('save-file', async (_event: IpcMainInvokeEvent, filePath: string, arrayBuffer: ArrayBuffer) => {
   if (!filePath) return { ok: false, error: 'no file path' };
-  const win = BrowserWindow.fromWebContents(event.sender);
-  const { response } = await dialog.showMessageBox(win, {
-    type: 'question', buttons: ['Replace', 'Cancel'],
-    defaultId: 0, cancelId: 1,
-    title: 'Save', message: `Replace "${path.basename(filePath)}"?`,
-    detail: 'The existing file will be overwritten with your annotated version.',
-  });
-  if (response !== 0) return { ok: false, error: 'cancelled' };
   try {
     fs.writeFileSync(filePath, Buffer.from(arrayBuffer));
     return { ok: true };

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,17 +234,27 @@ ipcMain.handle('reveal-in-explorer', (_event: IpcMainInvokeEvent, filePath: stri
   return { ok: true };
 });
 
-// Open the PDF file in a hidden Chromium window and invoke the system print dialog.
+// Open the PDF file in a Chromium window and invoke the system print dialog.
 // This bypasses the canvas renderer entirely so the output is always correct.
 ipcMain.handle('print-pdf', async (_event: IpcMainInvokeEvent, filePath: string): Promise<{ ok: boolean; error?: string }> => {
   if (!filePath || !fs.existsSync(filePath)) return { ok: false, error: 'File not found.' };
 
   const printWin: BW = new BrowserWindow({
     show: false,
+    skipTaskbar: true,
     webPreferences: { nodeIntegration: false, contextIsolation: true },
   });
 
   await printWin.loadURL('file:///' + filePath.replace(/\\/g, '/'));
+
+  // Chromium skips GPU compositing for windows that are never shown, producing blank
+  // print output. Show the window (without stealing focus) so the PDF viewer renders,
+  // then wait for the PDF title update which signals the viewer has finished loading.
+  printWin.showInactive();
+  await new Promise<void>(resolve => {
+    const tid = setTimeout(resolve, 3000);
+    printWin.webContents.once('page-title-updated', () => { clearTimeout(tid); resolve(); });
+  });
 
   return new Promise(resolve => {
     printWin.webContents.print({ silent: false }, (success: boolean, errorType: string) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,6 +234,26 @@ ipcMain.handle('reveal-in-explorer', (_event: IpcMainInvokeEvent, filePath: stri
   return { ok: true };
 });
 
+// Open the PDF file in a hidden Chromium window and invoke the system print dialog.
+// This bypasses the canvas renderer entirely so the output is always correct.
+ipcMain.handle('print-pdf', async (_event: IpcMainInvokeEvent, filePath: string): Promise<{ ok: boolean; error?: string }> => {
+  if (!filePath || !fs.existsSync(filePath)) return { ok: false, error: 'File not found.' };
+
+  const printWin: BW = new BrowserWindow({
+    show: false,
+    webPreferences: { nodeIntegration: false, contextIsolation: true },
+  });
+
+  await printWin.loadURL('file:///' + filePath.replace(/\\/g, '/'));
+
+  return new Promise(resolve => {
+    printWin.webContents.print({ silent: false }, (success: boolean, errorType: string) => {
+      printWin.destroy();
+      resolve(success ? { ok: true } : { ok: false, error: errorType });
+    });
+  });
+});
+
 // Read / write the extension ID in the native messaging host manifest.
 // The manifest lives next to the Reamlet exe (installed and portable builds).
 function getManifestPath(): string {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -61,6 +61,9 @@ contextBridge.exposeInMainWorld('api', {
   // Show the file in its containing folder
   revealInExplorer: (filePath: string) => ipcRenderer.invoke('reveal-in-explorer', filePath),
 
+  // Print the PDF file directly via the system print dialog
+  printPdf: (filePath: string) => ipcRenderer.invoke('print-pdf', filePath),
+
   // Initiate a native OS file drag (for dragging into Outlook, Explorer, etc.)
   startDrag: (filePath: string) => ipcRenderer.send('start-drag', filePath),
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -61,17 +61,22 @@ contextBridge.exposeInMainWorld('api', {
   // Show the file in its containing folder
   revealInExplorer: (filePath: string) => ipcRenderer.invoke('reveal-in-explorer', filePath),
 
-  // Open a visible print preview window for the given PDF file
-  openPrintPreview: (filePath: string) => ipcRenderer.invoke('open-print-preview', filePath),
-
-  // Receive PDF data pushed from main into the print preview window
-  onPdfData: (callback: (data: { buffer: ArrayBuffer }) => void) => {
+  // Print preview APIs
+  openPrintPreview:       (filePath: string) => ipcRenderer.invoke('open-print-preview', filePath),
+  onPdfData:              (callback: (data: { buffer: ArrayBuffer }) => void) => {
     ipcRenderer.on('pdf-data', (_e: unknown, data: { buffer: ArrayBuffer }) => callback(data));
   },
-
-  // Trigger the system print dialog from the preview window
-  executePrint: (options: { copies: number; color: boolean; scaleFactor: number }) =>
-    ipcRenderer.invoke('execute-print', options),
+  getPrinters:            () => ipcRenderer.invoke('get-printers'),
+  openPrinterPreferences: (printerName: string) => ipcRenderer.invoke('open-printer-preferences', printerName),
+  executePrint: (options: {
+    deviceName:  string;
+    copies:      number;
+    color:       boolean;
+    collate:     boolean;
+    duplexMode:  string;
+    scaleFactor: number;
+    landscape:   boolean;
+  }) => ipcRenderer.invoke('execute-print', options),
 
   // Initiate a native OS file drag (for dragging into Outlook, Explorer, etc.)
   startDrag: (filePath: string) => ipcRenderer.send('start-drag', filePath),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -41,7 +41,7 @@ contextBridge.exposeInMainWorld('api', {
 
   // Subscribe to menu events
   onMenuEvent: (callback: (event: string) => void) => {
-    ['menu-open', 'menu-save', 'menu-save-copy', 'menu-close-tab', 'menu-reopen-tab', 'menu-extension-id']
+    ['menu-open', 'menu-save', 'menu-save-copy', 'menu-print', 'menu-close-tab', 'menu-reopen-tab', 'menu-extension-id']
       .forEach(ev => ipcRenderer.on(ev, () => callback(ev)));
   },
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -61,8 +61,17 @@ contextBridge.exposeInMainWorld('api', {
   // Show the file in its containing folder
   revealInExplorer: (filePath: string) => ipcRenderer.invoke('reveal-in-explorer', filePath),
 
-  // Print the PDF file directly via the system print dialog
-  printPdf: (filePath: string) => ipcRenderer.invoke('print-pdf', filePath),
+  // Open a visible print preview window for the given PDF file
+  openPrintPreview: (filePath: string) => ipcRenderer.invoke('open-print-preview', filePath),
+
+  // Receive PDF data pushed from main into the print preview window
+  onPdfData: (callback: (data: { buffer: ArrayBuffer }) => void) => {
+    ipcRenderer.on('pdf-data', (_e: unknown, data: { buffer: ArrayBuffer }) => callback(data));
+  },
+
+  // Trigger the system print dialog from the preview window
+  executePrint: (options: { copies: number; color: boolean; scaleFactor: number }) =>
+    ipcRenderer.invoke('execute-print', options),
 
   // Initiate a native OS file drag (for dragging into Outlook, Explorer, etc.)
   startDrag: (filePath: string) => ipcRenderer.send('start-drag', filePath),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -73,7 +73,7 @@ contextBridge.exposeInMainWorld('api', {
     copies:      number;
     color:       boolean;
     collate:     boolean;
-    duplexMode:  string;
+    duplexMode:  'simplex' | 'longEdge' | 'shortEdge';
     scaleFactor: number;
     landscape:   boolean;
   }) => ipcRenderer.invoke('execute-print', options),

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1314,6 +1314,51 @@ document.getElementById('btn-fit-h')!.addEventListener('click',  fitHeight);
 document.getElementById('btn-rotate')!.addEventListener('click', (e) => rotate(e.shiftKey));
 document.getElementById('btn-print')!.addEventListener('click',  () => window.print());
 
+// ── TEMPORARY PRINT DEBUG ──────────────────────────────────────
+{
+  const dbgEl = document.createElement('div');
+  dbgEl.id = 'print-debug-overlay';
+  dbgEl.style.cssText = 'display:none;position:fixed;top:0;left:0;background:yellow;color:black;font:12px monospace;padding:8px;z-index:9999;white-space:pre;';
+  document.body.appendChild(dbgEl);
+
+  window.addEventListener('beforeprint', () => {
+    const lines: string[] = [];
+    lines.push(`window inner: ${window.innerWidth}x${window.innerHeight}`);
+    lines.push(`devicePixelRatio: ${window.devicePixelRatio}`);
+
+    const wrappers = document.querySelectorAll<HTMLElement>('.page-wrapper');
+    lines.push(`page-wrapper count: ${wrappers.length}`);
+
+    wrappers.forEach((wrapper, i) => {
+      const cs = getComputedStyle(wrapper);
+      lines.push(`\nwrapper[${i}]:`);
+      lines.push(`  inline style: w=${wrapper.style.width} h=${wrapper.style.height}`);
+      lines.push(`  computed:     w=${cs.width} h=${cs.height}`);
+      lines.push(`  opacity: inline=${wrapper.style.opacity} computed=${cs.opacity}`);
+
+      wrapper.querySelectorAll<HTMLCanvasElement>('canvas').forEach((c, j) => {
+        const cc = getComputedStyle(c);
+        let hasContent = false;
+        try {
+          const px = c.getContext('2d')?.getImageData(c.width >> 1, c.height >> 1, 1, 1).data;
+          hasContent = !!px && px[3] > 0;
+        } catch { /* tainted or no context */ }
+        lines.push(`  canvas[${j}] .${c.className}: attr=${c.width}x${c.height} computed=${cc.width}x${cc.height} hasContent=${hasContent}`);
+      });
+    });
+
+    const text = lines.join('\n');
+    console.log('[PRINT DEBUG]\n' + text);
+    dbgEl.textContent = text;
+    dbgEl.style.display = 'block';
+  });
+
+  window.addEventListener('afterprint', () => {
+    dbgEl.style.display = 'none';
+  });
+}
+// ── END PRINT DEBUG ────────────────────────────────────────────
+
 btnBold.addEventListener('click', () => {
   if (!activeTab?.annotator) return;
   const next = !activeTab.annotator.textBold;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -927,8 +927,17 @@ async function saveTab(tab: Tab | null) {
 
   const bytes = await embedAnnotations(tab.pdfBytes, annotations, viewer);
 
-  // Real on-disk file: overwrite after confirmation.
+  // Real on-disk file: confirm overwrite, then save.
   if (tab.filePath && /[\\/]/.test(tab.filePath)) {
+    const name   = tab.filePath.replace(/.*[\\/]/, '');
+    const choice = await showDialog({
+      title:     'Save',
+      message:   `Replace "${name}"?`,
+      buttons:   ['Replace', 'Cancel'],
+      defaultId: 0,
+      cancelId:  1,
+    });
+    if (choice !== 0) return false;
     const res = await window.api.saveFile(tab.filePath, bytes.buffer as ArrayBuffer);
     if (res.ok) {
       tab.pdfBytes     = bytes;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1412,6 +1412,7 @@ const _menuActions = {
   'open':        () => openFile(),
   'save':        () => saveTab(activeTab),
   'save-copy':   () => saveTabCopy(activeTab),
+  'print':       () => printTab(activeTab),
   'close-tab':   () => { if (activeTab) requestCloseTab(activeTab); },
   'reopen-tab':  () => reopenLastTab(),
   'quit':        () => window.close(),

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1468,6 +1468,7 @@ window.api.onMenuEvent((event) => {
     case 'menu-open':         openFile(); break;
     case 'menu-save':         saveTab(activeTab); break;
     case 'menu-save-copy':    saveTabCopy(activeTab); break;
+    case 'menu-print':        printTab(activeTab); break;
     case 'menu-close-tab':    if (activeTab) requestCloseTab(activeTab); break;
     case 'menu-reopen-tab':   reopenLastTab(); break;
     case 'menu-extension-id': _openExtensionIdModal(); break;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -329,7 +329,7 @@ tabContextMenu.addEventListener('mousedown', (e) => {
     case 'close':        requestCloseTab(tab); break;
     case 'save':         saveTab(tab); break;
     case 'save-as':      saveTabCopy(tab); break;
-    case 'print':        switchTab(tab); window.print(); break;
+    case 'print':        switchTab(tab); printTab(tab); break;
     case 'copy-file':    window.api.copyFileToClipboard(tab.filePath!); break;
     case 'reveal':       window.api.revealInExplorer(tab.filePath!); break;
     case 'close-others':
@@ -993,6 +993,15 @@ async function saveTabCopy(tab: Tab | null) {
   return false;
 }
 
+async function printTab(tab: Tab | null) {
+  if (!tab) return;
+  if (!tab.filePath) {
+    await window.api.showMessageBox({ type: 'info', message: 'Save the document before printing.', buttons: ['OK'] });
+    return;
+  }
+  await window.api.printPdf(tab.filePath);
+}
+
 async function reopenLastTab() {
   if (_closedTabStack.length === 0) return;
   const { filePath } = _closedTabStack.pop()!;
@@ -1312,52 +1321,7 @@ document.getElementById('btn-redo')!.addEventListener('click',   () => activeTab
 document.getElementById('btn-fit')!.addEventListener('click',    fitWidth);
 document.getElementById('btn-fit-h')!.addEventListener('click',  fitHeight);
 document.getElementById('btn-rotate')!.addEventListener('click', (e) => rotate(e.shiftKey));
-document.getElementById('btn-print')!.addEventListener('click',  () => window.print());
-
-// ── TEMPORARY PRINT DEBUG ──────────────────────────────────────
-{
-  const dbgEl = document.createElement('div');
-  dbgEl.id = 'print-debug-overlay';
-  dbgEl.style.cssText = 'display:none;position:fixed;top:0;left:0;background:yellow;color:black;font:12px monospace;padding:8px;z-index:9999;white-space:pre;';
-  document.body.appendChild(dbgEl);
-
-  window.addEventListener('beforeprint', () => {
-    const lines: string[] = [];
-    lines.push(`window inner: ${window.innerWidth}x${window.innerHeight}`);
-    lines.push(`devicePixelRatio: ${window.devicePixelRatio}`);
-
-    const wrappers = document.querySelectorAll<HTMLElement>('.page-wrapper');
-    lines.push(`page-wrapper count: ${wrappers.length}`);
-
-    wrappers.forEach((wrapper, i) => {
-      const cs = getComputedStyle(wrapper);
-      lines.push(`\nwrapper[${i}]:`);
-      lines.push(`  inline style: w=${wrapper.style.width} h=${wrapper.style.height}`);
-      lines.push(`  computed:     w=${cs.width} h=${cs.height}`);
-      lines.push(`  opacity: inline=${wrapper.style.opacity} computed=${cs.opacity}`);
-
-      wrapper.querySelectorAll<HTMLCanvasElement>('canvas').forEach((c, j) => {
-        const cc = getComputedStyle(c);
-        let hasContent = false;
-        try {
-          const px = c.getContext('2d')?.getImageData(c.width >> 1, c.height >> 1, 1, 1).data;
-          hasContent = !!px && px[3] > 0;
-        } catch { /* tainted or no context */ }
-        lines.push(`  canvas[${j}] .${c.className}: attr=${c.width}x${c.height} computed=${cc.width}x${cc.height} hasContent=${hasContent}`);
-      });
-    });
-
-    const text = lines.join('\n');
-    console.log('[PRINT DEBUG]\n' + text);
-    dbgEl.textContent = text;
-    dbgEl.style.display = 'block';
-  });
-
-  window.addEventListener('afterprint', () => {
-    dbgEl.style.display = 'none';
-  });
-}
-// ── END PRINT DEBUG ────────────────────────────────────────────
+document.getElementById('btn-print')!.addEventListener('click',  () => printTab(activeTab));
 
 btnBold.addEventListener('click', () => {
   if (!activeTab?.annotator) return;
@@ -1421,7 +1385,7 @@ document.addEventListener('keydown', async (e) => {
       e.preventDefault(); ann.copy(); return;
     }
   }
-  if (ctrl && e.key === 'p') { e.preventDefault(); window.print(); return; }
+  if (ctrl && e.key === 'p') { e.preventDefault(); printTab(activeTab); return; }
   if (ctrl && e.key === 'r') { e.preventDefault(); if (activeTab) _applyZoomNow(activeTab.viewer.scale); return; }
   if (ctrl && e.key === 'f') { e.preventDefault(); finder.open(); return; }
 

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -999,7 +999,7 @@ async function printTab(tab: Tab | null) {
     await window.api.showMessageBox({ type: 'info', message: 'Save the document before printing.', buttons: ['OK'] });
     return;
   }
-  await window.api.printPdf(tab.filePath);
+  await window.api.openPrintPreview(tab.filePath);
 }
 
 async function reopenLastTab() {

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -999,6 +999,19 @@ async function printTab(tab: Tab | null) {
     await window.api.showMessageBox({ type: 'info', message: 'Save the document before printing.', buttons: ['OK'] });
     return;
   }
+  if (tab.dirty) {
+    const choice = await window.api.showMessageBox({
+      type: 'question',
+      message: 'Save before printing?',
+      detail: 'The document has unsaved annotations. Save now so they appear in the printed output.',
+      buttons: ['Save and Print', 'Cancel'],
+      defaultId: 0,
+      cancelId: 1,
+    });
+    if (choice !== 0) return;
+    await saveTab(tab);
+    if (tab.dirty) return; // save was cancelled or failed
+  }
   await window.api.openPrintPreview(tab.filePath);
 }
 

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -993,20 +993,77 @@ async function saveTabCopy(tab: Tab | null) {
   return false;
 }
 
+// ── Generic custom dialog ──────────────────────────────────────
+// Builds a modal matching the app's existing style and resolves with
+// the index of the button the user clicked (Escape resolves cancelId).
+function showDialog(options: {
+  title:     string;
+  message:   string;
+  buttons:   string[];
+  defaultId?: number;
+  cancelId?:  number;
+}): Promise<number> {
+  return new Promise(resolve => {
+    const cancelId  = options.cancelId  ?? options.buttons.length - 1;
+    const defaultId = options.defaultId ?? 0;
+
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+
+    const box = document.createElement('div');
+    box.className = 'modal-box';
+    box.style.minWidth = '340px';
+
+    const titleEl = document.createElement('div');
+    titleEl.className = 'modal-title';
+    titleEl.textContent = options.title;
+    box.appendChild(titleEl);
+
+    const msgEl = document.createElement('p');
+    msgEl.className = 'modal-hint';
+    msgEl.textContent = options.message;
+    box.appendChild(msgEl);
+
+    const footer = document.createElement('div');
+    footer.className = 'modal-footer';
+
+    const dismiss = (idx: number) => {
+      document.removeEventListener('keydown', onKey);
+      document.body.removeChild(overlay);
+      resolve(idx);
+    };
+
+    options.buttons.forEach((label, i) => {
+      const btn = document.createElement('button');
+      btn.className = 'modal-btn' + (i === defaultId ? ' primary' : '');
+      btn.textContent = label;
+      btn.addEventListener('click', () => dismiss(i));
+      footer.appendChild(btn);
+    });
+
+    box.appendChild(footer);
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') dismiss(cancelId); };
+    document.addEventListener('keydown', onKey);
+  });
+}
+
 async function printTab(tab: Tab | null) {
   if (!tab) return;
   if (!tab.filePath) {
-    await window.api.showMessageBox({ type: 'info', message: 'Save the document before printing.', buttons: ['OK'] });
+    await showDialog({ title: 'Print', message: 'Save the document before printing.', buttons: ['OK'], defaultId: 0, cancelId: 0 });
     return;
   }
   if (tab.dirty) {
-    const choice = await window.api.showMessageBox({
-      type: 'question',
-      message: 'Save before printing?',
-      detail: 'The document has unsaved annotations. Save now so they appear in the printed output.',
-      buttons: ['Save and Print', 'Cancel'],
+    const name   = tab.filePath.replace(/.*[\\/]/, '');
+    const choice = await showDialog({
+      title:     'Unsaved Changes',
+      message:   `"${name}" has unsaved annotations. Save now so they appear in the printed output.`,
+      buttons:   ['Save and Print', 'Cancel'],
       defaultId: 0,
-      cancelId: 1,
+      cancelId:  1,
     });
     if (choice !== 0) return;
     await saveTab(tab);
@@ -1623,13 +1680,12 @@ async function _executeCombine() {
       const name    = tab.filePath ? tab.filePath.replace(/.*[\\/]/, '') : 'Untitled';
       const hasPath = tab.filePath && /[\\/]/.test(tab.filePath);
       const buttons = ['Discard changes', ...(hasPath ? ['Save'] : []), 'Save As\u2026', 'Cancel'];
-      const choice  = await window.api.showMessageBox({
-        type:      'question',
+      const saveIdx = buttons.includes('Save') ? buttons.indexOf('Save') : buttons.indexOf('Save As\u2026');
+      const choice  = await showDialog({
         title:     'Unsaved Changes',
-        message:   `\u201c${name}\u201d has unsaved annotations.`,
-        detail:    'Choose how to handle them before combining.',
+        message:   `\u201c${name}\u201d has unsaved annotations. Choose how to handle them before combining.`,
         buttons,
-        defaultId: 0,
+        defaultId: saveIdx,
         cancelId:  buttons.indexOf('Cancel'),
       });
       const action = buttons[choice];

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -41,6 +41,7 @@ let pageData: PageData[] = []; // index 0 = page 1
     const opt = document.createElement('option');
     opt.textContent = 'No printers found';
     selPrinter.appendChild(opt);
+    btnPrint.disabled = true;
     return;
   }
   printers.forEach((p: { name: string; isDefault: boolean }) => {
@@ -125,6 +126,15 @@ function buildComposite(pageSlots: number[], cols: number, targetW: number, targ
       const scale = Math.min(slotW / naturalW, slotH / naturalH);
       const dw = naturalW * scale, dh = naturalH * scale;
       ctx.drawImage(img, slotX + (slotW - dw) / 2, slotY + (slotH - dh) / 2, dw, dh);
+    } else {
+      // Blank slot — subtle fill and label so users know it's intentional
+      ctx.fillStyle = '#f0f0f0';
+      ctx.fillRect(slotX + 0.5, slotY + 0.5, slotW - 1, slotH - 1);
+      ctx.font = `${Math.round(Math.min(slotW, slotH) * 0.07)}px system-ui, sans-serif`;
+      ctx.fillStyle = '#bbb';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('Blank', slotX + slotW / 2, slotY + slotH / 2);
     }
     // Faint slot border
     ctx.strokeStyle = '#ddd';
@@ -233,43 +243,70 @@ btnPrint.addEventListener('click', async () => {
 
   btnPrint.disabled = true;
   statusEl.textContent = 'Printing…';
-  await window.api.executePrint({
-    deviceName: selPrinter.value,
-    copies,
-    color:      !grey,
-    collate:    chkCollate.checked,
-    duplexMode,
-    scaleFactor,
-    landscape,
-  });
+  try {
+    const result = await window.api.executePrint({
+      deviceName: selPrinter.value,
+      copies,
+      color:      !grey,
+      collate:    chkCollate.checked,
+      duplexMode,
+      scaleFactor,
+      landscape,
+    });
+    if (!result.ok) {
+      statusEl.textContent = `Print failed: ${result.error ?? 'unknown error'}`;
+      btnPrint.disabled = false;
+      return;
+    }
+  } catch (err) {
+    statusEl.textContent = `Print error: ${(err as Error).message}`;
+    btnPrint.disabled = false;
+    return;
+  }
   window.close();
 });
 
 // ── Receive PDF data from main ─────────────────────────────────
 window.api.onPdfData(async ({ buffer }) => {
   statusEl.textContent = 'Rendering pages…';
-  const bytes  = new Uint8Array(buffer);
-  const pdfDoc = await pdfjsLib.getDocument({ data: bytes }).promise;
-  totalPages   = pdfDoc.numPages;
 
-  for (let pageNum = 1; pageNum <= totalPages; pageNum++) {
-    const page     = await pdfDoc.getPage(pageNum);
-    const viewport = page.getViewport({ scale: 1.5 });
-    const canvas   = document.createElement('canvas');
-    canvas.width   = viewport.width;
-    canvas.height  = viewport.height;
-    await page.render({ canvasContext: canvas.getContext('2d')!, viewport }).promise;
+  let pdfDoc;
+  try {
+    const bytes = new Uint8Array(buffer);
+    pdfDoc = await pdfjsLib.getDocument({ data: bytes }).promise;
+  } catch (err) {
+    statusEl.textContent = `Failed to load PDF: ${(err as Error).message}`;
+    return;
+  }
+  totalPages = pdfDoc.numPages;
 
-    const dataUrl  = canvas.toDataURL('image/png');
-    const img      = new Image();
-    await new Promise<void>(resolve => { img.onload = () => resolve(); img.src = dataUrl; });
+  try {
+    for (let pageNum = 1; pageNum <= totalPages; pageNum++) {
+      const page     = await pdfDoc.getPage(pageNum);
+      const viewport = page.getViewport({ scale: 1.5 });
+      const canvas   = document.createElement('canvas');
+      canvas.width   = viewport.width;
+      canvas.height  = viewport.height;
+      await page.render({ canvasContext: canvas.getContext('2d')!, viewport }).promise;
 
-    pageData.push({
-      img,
-      naturalW: viewport.width  / 1.5,
-      naturalH: viewport.height / 1.5,
-    });
-    statusEl.textContent = `Rendering… ${pageNum}/${totalPages}`;
+      const dataUrl  = canvas.toDataURL('image/png');
+      const img      = new Image();
+      await new Promise<void>(resolve => {
+        img.onload  = () => resolve();
+        img.onerror = () => resolve(); // silently skip bad frames
+        img.src = dataUrl;
+      });
+
+      pageData.push({
+        img,
+        naturalW: viewport.width  / 1.5,
+        naturalH: viewport.height / 1.5,
+      });
+      statusEl.textContent = `Rendering… ${pageNum}/${totalPages}`;
+    }
+  } catch (err) {
+    statusEl.textContent = `Rendering error: ${(err as Error).message}`;
+    return;
   }
 
   statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -74,7 +74,7 @@ function parsePageRange(str: string): Set<number> | null {
       if (!isNaN(n) && n >= 1 && n <= totalPages) result.add(n);
     }
   }
-  return result.size > 0 ? result : null;
+  return result;
 }
 
 // ── Booklet ordering ──────────────────────────────────────────
@@ -239,7 +239,9 @@ btnPrint.addEventListener('click', async () => {
   const scaleVal    = selScale.value;
   const scaleFactor = (scaleVal === 'fit' || scaleVal === '100') ? 100 : parseInt(scaleVal);
   const duplexMode  = selDuplex.value as 'simplex' | 'longEdge' | 'shortEdge';
-  const landscape   = chkBooklet.checked; // booklet composites are landscape
+  // Booklet composites are always landscape; otherwise follow the first page's orientation
+  const landscape   = chkBooklet.checked ||
+    (pageData.length > 0 && pageData[0].naturalW > pageData[0].naturalH);
 
   btnPrint.disabled = true;
   statusEl.textContent = 'Printing…';

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -29,6 +29,7 @@ const zoomLabel      = document.getElementById('zoom-label')!;
 // ── State ─────────────────────────────────────────────────────
 let totalPages = 0;
 let previewZoom = 1.0;
+let printOrientation: 'portrait' | 'landscape' = 'portrait';
 
 const ZOOM_STEPS = [0.25, 0.33, 0.5, 0.67, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0];
 
@@ -172,10 +173,13 @@ function buildComposite(pageSlots: number[], cols: number, targetW: number, targ
 }
 
 // ── Add a page wrapper to the preview ────────────────────────
-function addPreviewPage(imgEl: HTMLImageElement, displayW: number, displayH: number) {
-  imgEl.style.cssText = `width:${displayW}px; height:${displayH}px;`;
+// paperW/H are the paper dimensions; imgEl scales to fit inside.
+function addPreviewPage(imgEl: HTMLImageElement, paperW: number, paperH: number) {
+  imgEl.style.cssText = '';
   const wrapper = document.createElement('div');
   wrapper.className = 'print-page';
+  wrapper.style.width  = `${paperW}px`;
+  wrapper.style.height = `${paperH}px`;
   wrapper.appendChild(imgEl);
   previewArea.appendChild(wrapper);
 }
@@ -193,14 +197,20 @@ function renderPreview() {
   const refW = pageData[0].naturalW;
   const refH = pageData[0].naturalH;
 
+  // Paper dimensions: honour orientation toggle (booklet is always landscape)
+  const shortSide = Math.min(refW, refH);
+  const longSide  = Math.max(refW, refH);
+  const paperW = (isBooklet || printOrientation === 'landscape') ? longSide : shortSide;
+  const paperH = (isBooklet || printOrientation === 'landscape') ? shortSide : longSide;
+
   if (isBooklet) {
     // Booklet: always uses all pages; composites are landscape (2× wide)
     const sheets = getBookletOrder(totalPages);
     sheets.forEach(sheet => {
       (['front', 'back'] as const).forEach(side => {
         const [lp, rp] = sheet[side];
-        const img = buildComposite([lp, rp], 2, refW * 2, refH);
-        addPreviewPage(img, refW * 2, refH);
+        const img = buildComposite([lp, rp], 2, paperW * 2, paperH);
+        addPreviewPage(img, paperW * 2, paperH);
       });
     });
   } else if (pps > 1) {
@@ -215,17 +225,17 @@ function renderPreview() {
     for (let i = 0; i < visible.length; i += pps) {
       const chunk = visible.slice(i, i + pps);
       while (chunk.length < pps) chunk.push(0); // pad with blanks
-      const img = buildComposite(chunk, cols, refW, refH);
-      addPreviewPage(img, refW, refH);
+      const img = buildComposite(chunk, cols, paperW, paperH);
+      addPreviewPage(img, paperW, paperH);
     }
   } else {
-    // Single page per sheet
+    // Single page per sheet — show each page letterboxed on the selected paper size
     for (let p = 1; p <= totalPages; p++) {
       if (pageRange !== null && !pageRange.has(p)) continue;
-      const { img, naturalW, naturalH } = pageData[p - 1];
+      const { img } = pageData[p - 1];
       const clone = new Image();
       clone.src = img.src;
-      addPreviewPage(clone, naturalW, naturalH);
+      addPreviewPage(clone, paperW, paperH);
     }
   }
 
@@ -254,6 +264,11 @@ chkBooklet.addEventListener('change', () => {
 });
 document.querySelectorAll('input[name="color"]').forEach(el =>
   el.addEventListener('change', updateGreyscale));
+document.querySelectorAll('input[name="orientation"]').forEach(el =>
+  el.addEventListener('change', () => {
+    printOrientation = (document.querySelector('input[name="orientation"]:checked') as HTMLInputElement).value as 'portrait' | 'landscape';
+    renderPreview();
+  }));
 
 btnClose.addEventListener('click', () => window.close());
 
@@ -263,8 +278,7 @@ btnPrint.addEventListener('click', async () => {
   const scaleVal    = selScale.value;
   const scaleFactor = (scaleVal === 'fit' || scaleVal === '100') ? 100 : parseInt(scaleVal);
   const duplexMode  = selDuplex.value as 'simplex' | 'longEdge' | 'shortEdge';
-  // Orientation is handled per-page via CSS @page named pages; always default portrait here
-  const landscape   = false;
+  const landscape   = chkBooklet.checked || printOrientation === 'landscape';
 
   btnPrint.disabled = true;
   statusEl.textContent = 'Printing…';

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -272,6 +272,14 @@ document.querySelectorAll('input[name="orientation"]').forEach(el =>
 
 btnClose.addEventListener('click', () => window.close());
 
+window.addEventListener('wheel', (e: WheelEvent) => {
+  if (!e.ctrlKey) return;
+  e.preventDefault();
+  const curIdx = ZOOM_STEPS.indexOf(previewZoom);
+  if (e.deltaY < 0 && curIdx < ZOOM_STEPS.length - 1) setPreviewZoom(ZOOM_STEPS[curIdx + 1]);
+  if (e.deltaY > 0 && curIdx > 0)                      setPreviewZoom(ZOOM_STEPS[curIdx - 1]);
+}, { passive: false });
+
 btnPrint.addEventListener('click', async () => {
   const copies      = Math.max(1, parseInt(inpCopies.value) || 1);
   const grey        = (document.querySelector('input[name="color"]:checked') as HTMLInputElement)?.value === 'grey';

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -32,23 +32,40 @@ let previewZoom = 1.0;
 let printOrientation: 'portrait' | 'landscape' = 'portrait';
 
 const ZOOM_STEPS = [0.25, 0.33, 0.5, 0.67, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0];
+const ZOOM_MIN = ZOOM_STEPS[0];
+const ZOOM_MAX = ZOOM_STEPS[ZOOM_STEPS.length - 1];
 
 function setPreviewZoom(z: number) {
   previewZoom = z;
   zoomLabel.textContent = `${Math.round(z * 100)}%`;
-  const curIdx = ZOOM_STEPS.indexOf(z);
-  btnZoomOut.disabled = curIdx <= 0;
-  btnZoomIn.disabled  = curIdx >= ZOOM_STEPS.length - 1;
+  btnZoomOut.disabled = z <= ZOOM_MIN;
+  btnZoomIn.disabled  = z >= ZOOM_MAX;
   previewArea.style.zoom = String(z);
 }
 
+function fitToWidth() {
+  if (pageData.length === 0) return;
+  const padding   = 48; // 24px each side
+  const availW    = previewArea.clientWidth - padding;
+  const refW      = pageData[0].naturalW;
+  const refH      = pageData[0].naturalH;
+  const shortSide = Math.min(refW, refH);
+  const longSide  = Math.max(refW, refH);
+  const isBooklet = chkBooklet.checked;
+  const paperW    = isBooklet
+    ? (printOrientation === 'landscape' ? longSide : shortSide) * 2
+    : (printOrientation === 'landscape' ? longSide : shortSide);
+  const z = Math.min(Math.max(availW / paperW, ZOOM_MIN), ZOOM_MAX);
+  setPreviewZoom(Math.round(z * 1000) / 1000);
+}
+
 btnZoomOut.addEventListener('click', () => {
-  const curIdx = ZOOM_STEPS.indexOf(previewZoom);
-  if (curIdx > 0) setPreviewZoom(ZOOM_STEPS[curIdx - 1]);
+  const prev = [...ZOOM_STEPS].reverse().find(s => s < previewZoom - 0.001);
+  if (prev !== undefined) setPreviewZoom(prev);
 });
 btnZoomIn.addEventListener('click', () => {
-  const curIdx = ZOOM_STEPS.indexOf(previewZoom);
-  if (curIdx < ZOOM_STEPS.length - 1) setPreviewZoom(ZOOM_STEPS[curIdx + 1]);
+  const next = ZOOM_STEPS.find(s => s > previewZoom + 0.001);
+  if (next !== undefined) setPreviewZoom(next);
 });
 
 interface PageData {
@@ -267,6 +284,7 @@ document.querySelectorAll('input[name="color"]').forEach(el =>
 document.querySelectorAll('input[name="orientation"]').forEach(el =>
   el.addEventListener('change', () => {
     printOrientation = (document.querySelector('input[name="orientation"]:checked') as HTMLInputElement).value as 'portrait' | 'landscape';
+    fitToWidth();
     renderPreview();
   }));
 
@@ -275,9 +293,8 @@ btnClose.addEventListener('click', () => window.close());
 window.addEventListener('wheel', (e: WheelEvent) => {
   if (!e.ctrlKey) return;
   e.preventDefault();
-  const curIdx = ZOOM_STEPS.indexOf(previewZoom);
-  if (e.deltaY < 0 && curIdx < ZOOM_STEPS.length - 1) setPreviewZoom(ZOOM_STEPS[curIdx + 1]);
-  if (e.deltaY > 0 && curIdx > 0)                      setPreviewZoom(ZOOM_STEPS[curIdx - 1]);
+  if (e.deltaY < 0) { const next = ZOOM_STEPS.find(s => s > previewZoom + 0.001);            if (next !== undefined) setPreviewZoom(next); }
+  if (e.deltaY > 0) { const prev = [...ZOOM_STEPS].reverse().find(s => s < previewZoom - 0.001); if (prev !== undefined) setPreviewZoom(prev); }
 }, { passive: false });
 
 btnPrint.addEventListener('click', async () => {
@@ -357,5 +374,6 @@ window.api.onPdfData(async ({ buffer }) => {
   }
 
   statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;
+  fitToWidth();
   renderPreview();
 });

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -22,9 +22,34 @@ const chkBooklet     = document.getElementById('chk-booklet')      as HTMLInputE
 const btnPrint       = document.getElementById('btn-print')        as HTMLButtonElement;
 const btnClose       = document.getElementById('btn-close')        as HTMLButtonElement;
 const statusEl       = document.getElementById('status')!;
+const btnZoomOut     = document.getElementById('btn-zoom-out')     as HTMLButtonElement;
+const btnZoomIn      = document.getElementById('btn-zoom-in')      as HTMLButtonElement;
+const zoomLabel      = document.getElementById('zoom-label')!;
 
 // ── State ─────────────────────────────────────────────────────
 let totalPages = 0;
+let previewZoom = 1.0;
+
+const ZOOM_STEPS = [0.25, 0.33, 0.5, 0.67, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0];
+
+function setPreviewZoom(z: number) {
+  previewZoom = z;
+  zoomLabel.textContent = `${Math.round(z * 100)}%`;
+  const minIdx = 0, maxIdx = ZOOM_STEPS.length - 1;
+  const curIdx = ZOOM_STEPS.indexOf(z);
+  btnZoomOut.disabled = curIdx <= minIdx;
+  btnZoomIn.disabled  = curIdx >= maxIdx;
+  renderPreview();
+}
+
+btnZoomOut.addEventListener('click', () => {
+  const curIdx = ZOOM_STEPS.indexOf(previewZoom);
+  if (curIdx > 0) setPreviewZoom(ZOOM_STEPS[curIdx - 1]);
+});
+btnZoomIn.addEventListener('click', () => {
+  const curIdx = ZOOM_STEPS.indexOf(previewZoom);
+  if (curIdx < ZOOM_STEPS.length - 1) setPreviewZoom(ZOOM_STEPS[curIdx + 1]);
+});
 
 interface PageData {
   img: HTMLImageElement; // loaded at 1.5× scale
@@ -149,9 +174,12 @@ function buildComposite(pageSlots: number[], cols: number, targetW: number, targ
 
 // ── Add a page wrapper to the preview ────────────────────────
 function addPreviewPage(imgEl: HTMLImageElement, displayW: number, displayH: number) {
-  imgEl.style.cssText = `width:${displayW}px; height:${displayH}px; max-width:100%;`;
+  const scaledW = Math.round(displayW * previewZoom);
+  const scaledH = Math.round(displayH * previewZoom);
+  imgEl.style.cssText = `width:${scaledW}px; height:${scaledH}px; max-width:100%;`;
   const wrapper = document.createElement('div');
   wrapper.className = 'print-page';
+  if (displayW > displayH) wrapper.classList.add('landscape');
   wrapper.appendChild(imgEl);
   previewArea.appendChild(wrapper);
 }
@@ -239,9 +267,8 @@ btnPrint.addEventListener('click', async () => {
   const scaleVal    = selScale.value;
   const scaleFactor = (scaleVal === 'fit' || scaleVal === '100') ? 100 : parseInt(scaleVal);
   const duplexMode  = selDuplex.value as 'simplex' | 'longEdge' | 'shortEdge';
-  // Booklet composites are always landscape; otherwise follow the first page's orientation
-  const landscape   = chkBooklet.checked ||
-    (pageData.length > 0 && pageData[0].naturalW > pageData[0].naturalH);
+  // Orientation is handled per-page via CSS @page named pages; always default portrait here
+  const landscape   = false;
 
   btnPrint.disabled = true;
   statusEl.textContent = 'Printing…';

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -35,11 +35,10 @@ const ZOOM_STEPS = [0.25, 0.33, 0.5, 0.67, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75,
 function setPreviewZoom(z: number) {
   previewZoom = z;
   zoomLabel.textContent = `${Math.round(z * 100)}%`;
-  const minIdx = 0, maxIdx = ZOOM_STEPS.length - 1;
   const curIdx = ZOOM_STEPS.indexOf(z);
-  btnZoomOut.disabled = curIdx <= minIdx;
-  btnZoomIn.disabled  = curIdx >= maxIdx;
-  renderPreview();
+  btnZoomOut.disabled = curIdx <= 0;
+  btnZoomIn.disabled  = curIdx >= ZOOM_STEPS.length - 1;
+  previewArea.style.zoom = String(z);
 }
 
 btnZoomOut.addEventListener('click', () => {
@@ -174,9 +173,7 @@ function buildComposite(pageSlots: number[], cols: number, targetW: number, targ
 
 // ── Add a page wrapper to the preview ────────────────────────
 function addPreviewPage(imgEl: HTMLImageElement, displayW: number, displayH: number) {
-  const scaledW = Math.round(displayW * previewZoom);
-  const scaledH = Math.round(displayH * previewZoom);
-  imgEl.style.cssText = `width:${scaledW}px; height:${scaledH}px; max-width:100%;`;
+  imgEl.style.cssText = `width:${displayW}px; height:${displayH}px;`;
   const wrapper = document.createElement('div');
   wrapper.className = 'print-page';
   wrapper.appendChild(imgEl);

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -1,0 +1,109 @@
+// Reamlet — Print Preview renderer
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// @ts-expect-error — pdfjs-dist direct path for Electron ESM
+import * as _pdfjsLib from '../../node_modules/pdfjs-dist/build/pdf.mjs';
+import type * as PDFJSLib from 'pdfjs-dist';
+const pdfjsLib = _pdfjsLib as unknown as typeof PDFJSLib;
+pdfjsLib.GlobalWorkerOptions.workerSrc =
+  new URL('../../node_modules/pdfjs-dist/build/pdf.worker.mjs', import.meta.url).href;
+
+const previewArea    = document.getElementById('preview-area')!;
+const inpCopies      = document.getElementById('inp-copies')      as HTMLInputElement;
+const selPages       = document.getElementById('sel-pages')       as HTMLSelectElement;
+const inpPagesCustom = document.getElementById('inp-pages-custom') as HTMLInputElement;
+const selScale       = document.getElementById('sel-scale')       as HTMLSelectElement;
+const btnPrint       = document.getElementById('btn-print')       as HTMLButtonElement;
+const btnClose       = document.getElementById('btn-close')       as HTMLButtonElement;
+const statusEl       = document.getElementById('status')!;
+
+let totalPages = 0;
+
+// Parse "1-3, 5, 7-9" into Set<number>
+function parsePageRange(str: string, total: number): Set<number> {
+  const result = new Set<number>();
+  for (const part of str.split(',')) {
+    const trimmed = part.trim();
+    const range = trimmed.match(/^(\d+)\s*[-\u2013]\s*(\d+)$/);
+    if (range) {
+      const from = parseInt(range[1]), to = parseInt(range[2]);
+      for (let p = Math.max(1, from); p <= Math.min(total, to); p++) result.add(p);
+    } else {
+      const n = parseInt(trimmed);
+      if (!isNaN(n) && n >= 1 && n <= total) result.add(n);
+    }
+  }
+  return result;
+}
+
+function updatePageVisibility() {
+  const mode = selPages.value;
+  const selected = mode === 'custom' && inpPagesCustom.value.trim()
+    ? parsePageRange(inpPagesCustom.value, totalPages)
+    : null; // null = all
+  document.querySelectorAll<HTMLElement>('.print-page').forEach(el => {
+    const page = parseInt(el.dataset.page!);
+    el.classList.toggle('excluded', selected !== null && !selected.has(page));
+  });
+}
+
+function updateGreyscale() {
+  const grey = (document.querySelector('input[name="color"]:checked') as HTMLInputElement)?.value === 'grey';
+  previewArea.classList.toggle('greyscale', grey);
+}
+
+function updateScale() {
+  const fit = selScale.value === 'fit';
+  document.querySelectorAll('.print-page').forEach(el => el.classList.toggle('fit', fit));
+}
+
+selPages.addEventListener('change', () => {
+  inpPagesCustom.classList.toggle('hidden', selPages.value !== 'custom');
+  updatePageVisibility();
+});
+inpPagesCustom.addEventListener('input', updatePageVisibility);
+document.querySelectorAll('input[name="color"]').forEach(el =>
+  el.addEventListener('change', updateGreyscale));
+selScale.addEventListener('change', updateScale);
+
+btnClose.addEventListener('click', () => window.close());
+
+btnPrint.addEventListener('click', async () => {
+  const copies   = Math.max(1, parseInt(inpCopies.value) || 1);
+  const grey     = (document.querySelector('input[name="color"]:checked') as HTMLInputElement)?.value === 'grey';
+  const scaleVal = selScale.value;
+  const scaleFactor = scaleVal === 'fit' || scaleVal === '100' ? 100 : parseInt(scaleVal);
+
+  btnPrint.disabled = true;
+  await window.api.executePrint({ copies, color: !grey, scaleFactor });
+  btnPrint.disabled = false;
+});
+
+window.api.onPdfData(async ({ buffer }) => {
+  statusEl.textContent = 'Rendering pages…';
+  const bytes  = new Uint8Array(buffer);
+  const pdfDoc = await pdfjsLib.getDocument({ data: bytes }).promise;
+  totalPages   = pdfDoc.numPages;
+
+  for (let pageNum = 1; pageNum <= totalPages; pageNum++) {
+    const page     = await pdfDoc.getPage(pageNum);
+    const viewport = page.getViewport({ scale: 1.5 });
+    const canvas   = document.createElement('canvas');
+    canvas.width   = viewport.width;
+    canvas.height  = viewport.height;
+    await page.render({ canvasContext: canvas.getContext('2d')!, viewport }).promise;
+
+    const img   = new Image();
+    img.src     = canvas.toDataURL('image/png');
+    img.style.cssText = `width: ${viewport.width / 1.5}px; height: auto;`;
+
+    const wrapper       = document.createElement('div');
+    wrapper.className   = 'print-page fit'; // fit is default
+    wrapper.dataset.page = String(pageNum);
+    wrapper.appendChild(img);
+    previewArea.appendChild(wrapper);
+  }
+
+  statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;
+  updateScale(); // apply initial scale state
+});

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -8,43 +8,194 @@ const pdfjsLib = _pdfjsLib as unknown as typeof PDFJSLib;
 pdfjsLib.GlobalWorkerOptions.workerSrc =
   new URL('../../node_modules/pdfjs-dist/build/pdf.worker.mjs', import.meta.url).href;
 
+// ── DOM refs ──────────────────────────────────────────────────
 const previewArea    = document.getElementById('preview-area')!;
-const inpCopies      = document.getElementById('inp-copies')      as HTMLInputElement;
-const selPages       = document.getElementById('sel-pages')       as HTMLSelectElement;
-const inpPagesCustom = document.getElementById('inp-pages-custom') as HTMLInputElement;
-const selScale       = document.getElementById('sel-scale')       as HTMLSelectElement;
-const btnPrint       = document.getElementById('btn-print')       as HTMLButtonElement;
-const btnClose       = document.getElementById('btn-close')       as HTMLButtonElement;
+const selPrinter     = document.getElementById('sel-printer')      as HTMLSelectElement;
+const btnPrinterPref = document.getElementById('btn-printer-pref') as HTMLButtonElement;
+const inpCopies      = document.getElementById('inp-copies')       as HTMLInputElement;
+const chkCollate     = document.getElementById('chk-collate')      as HTMLInputElement;
+const inpPages       = document.getElementById('inp-pages')        as HTMLInputElement;
+const selScale       = document.getElementById('sel-scale')        as HTMLSelectElement;
+const selPps         = document.getElementById('sel-pps')          as HTMLSelectElement;
+const selDuplex      = document.getElementById('sel-duplex')       as HTMLSelectElement;
+const chkBooklet     = document.getElementById('chk-booklet')      as HTMLInputElement;
+const btnPrint       = document.getElementById('btn-print')        as HTMLButtonElement;
+const btnClose       = document.getElementById('btn-close')        as HTMLButtonElement;
 const statusEl       = document.getElementById('status')!;
 
+// ── State ─────────────────────────────────────────────────────
 let totalPages = 0;
 
-// Parse "1-3, 5, 7-9" into Set<number>
-function parsePageRange(str: string, total: number): Set<number> {
+interface PageData {
+  img: HTMLImageElement; // loaded at 1.5× scale
+  naturalW: number;      // 1× CSS width (viewport.width / 1.5)
+  naturalH: number;      // 1× CSS height
+}
+let pageData: PageData[] = []; // index 0 = page 1
+
+// ── Printers ──────────────────────────────────────────────────
+(async () => {
+  const printers = await window.api.getPrinters();
+  selPrinter.innerHTML = '';
+  if (printers.length === 0) {
+    const opt = document.createElement('option');
+    opt.textContent = 'No printers found';
+    selPrinter.appendChild(opt);
+    return;
+  }
+  printers.forEach((p: { name: string; isDefault: boolean }) => {
+    const opt = document.createElement('option');
+    opt.value = p.name;
+    opt.textContent = p.name;
+    if (p.isDefault) opt.selected = true;
+    selPrinter.appendChild(opt);
+  });
+})();
+
+btnPrinterPref.addEventListener('click', () => {
+  if (selPrinter.value) window.api.openPrinterPreferences(selPrinter.value);
+});
+
+// ── Page range parsing ────────────────────────────────────────
+// Returns null for "all pages", or a Set<number> of selected page numbers.
+function parsePageRange(str: string): Set<number> | null {
+  const trimmed = str.trim();
+  if (!trimmed) return null;
   const result = new Set<number>();
-  for (const part of str.split(',')) {
-    const trimmed = part.trim();
-    const range = trimmed.match(/^(\d+)\s*[-\u2013]\s*(\d+)$/);
-    if (range) {
-      const from = parseInt(range[1]), to = parseInt(range[2]);
-      for (let p = Math.max(1, from); p <= Math.min(total, to); p++) result.add(p);
+  for (const part of trimmed.split(',')) {
+    const t = part.trim();
+    const rangeMatch = t.match(/^(\d+)\s*[-\u2013]\s*(\d+)$/);
+    if (rangeMatch) {
+      const from = parseInt(rangeMatch[1]), to = parseInt(rangeMatch[2]);
+      for (let p = Math.max(1, from); p <= Math.min(totalPages, to); p++) result.add(p);
     } else {
-      const n = parseInt(trimmed);
-      if (!isNaN(n) && n >= 1 && n <= total) result.add(n);
+      const n = parseInt(t);
+      if (!isNaN(n) && n >= 1 && n <= totalPages) result.add(n);
     }
   }
-  return result;
+  return result.size > 0 ? result : null;
 }
 
-function updatePageVisibility() {
-  const mode = selPages.value;
-  const selected = mode === 'custom' && inpPagesCustom.value.trim()
-    ? parsePageRange(inpPagesCustom.value, totalPages)
-    : null; // null = all
-  document.querySelectorAll<HTMLElement>('.print-page').forEach(el => {
-    const page = parseInt(el.dataset.page!);
-    el.classList.toggle('excluded', selected !== null && !selected.has(page));
+// ── Booklet ordering ──────────────────────────────────────────
+interface BookletSheet {
+  front: [number, number]; // [leftPage, rightPage] — both 1-indexed; 0 = blank
+  back:  [number, number];
+}
+
+function getBookletOrder(numPages: number): BookletSheet[] {
+  const totalSlots = Math.ceil(numPages / 4) * 4;
+  const numSheets  = totalSlots / 4;
+  const sheets: BookletSheet[] = [];
+  let low = 1, high = totalSlots;
+  for (let i = 0; i < numSheets; i++) {
+    // Per spec: front=[high, low], back=[low+1, high-1]
+    // "right page is high, left page is low" in the spec, but we render [left=high, right=low]
+    // which matches physical booklet layout (high=back_cover on left, low=front_cover on right)
+    sheets.push({ front: [high, low], back: [low + 1, high - 1] });
+    low  += 2;
+    high -= 2;
+  }
+  return sheets;
+}
+
+// ── Composite image builder ───────────────────────────────────
+// pageSlots: 1-indexed page numbers; 0 or >totalPages means blank
+// cols: number of columns in the grid
+// targetW/H: canvas output size in px
+function buildComposite(pageSlots: number[], cols: number, targetW: number, targetH: number): HTMLImageElement {
+  const rows = Math.ceil(pageSlots.length / cols);
+  const canvas = document.createElement('canvas');
+  canvas.width  = targetW;
+  canvas.height = targetH;
+  const ctx = canvas.getContext('2d')!;
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, targetW, targetH);
+
+  const slotW = targetW / cols;
+  const slotH = targetH / rows;
+
+  pageSlots.forEach((pageNum, idx) => {
+    const col  = idx % cols;
+    const row  = Math.floor(idx / cols);
+    const slotX = col * slotW;
+    const slotY = row * slotH;
+
+    if (pageNum >= 1 && pageNum <= totalPages) {
+      const { img, naturalW, naturalH } = pageData[pageNum - 1];
+      const scale = Math.min(slotW / naturalW, slotH / naturalH);
+      const dw = naturalW * scale, dh = naturalH * scale;
+      ctx.drawImage(img, slotX + (slotW - dw) / 2, slotY + (slotH - dh) / 2, dw, dh);
+    }
+    // Faint slot border
+    ctx.strokeStyle = '#ddd';
+    ctx.lineWidth = 0.5;
+    ctx.strokeRect(slotX + 0.25, slotY + 0.25, slotW - 0.5, slotH - 0.5);
   });
+
+  const out = new Image();
+  out.src = canvas.toDataURL('image/png');
+  return out;
+}
+
+// ── Add a page wrapper to the preview ────────────────────────
+function addPreviewPage(imgEl: HTMLImageElement, displayW: number, displayH: number) {
+  imgEl.style.cssText = `width:${displayW}px; height:${displayH}px; max-width:100%;`;
+  const wrapper = document.createElement('div');
+  wrapper.className = 'print-page';
+  wrapper.appendChild(imgEl);
+  previewArea.appendChild(wrapper);
+}
+
+// ── Build / refresh the preview ───────────────────────────────
+function renderPreview() {
+  if (pageData.length === 0) return;
+  previewArea.innerHTML = '';
+
+  const isBooklet = chkBooklet.checked;
+  const pps       = isBooklet ? 2 : (parseInt(selPps.value) || 1);
+  const pageRange = parsePageRange(inpPages.value);
+
+  // Reference dimensions (first page at 1× scale)
+  const refW = pageData[0].naturalW;
+  const refH = pageData[0].naturalH;
+
+  if (isBooklet) {
+    // Booklet: always uses all pages; composites are landscape (2× wide)
+    const sheets = getBookletOrder(totalPages);
+    sheets.forEach(sheet => {
+      (['front', 'back'] as const).forEach(side => {
+        const [lp, rp] = sheet[side];
+        const img = buildComposite([lp, rp], 2, refW * 2, refH);
+        addPreviewPage(img, refW * 2, refH);
+      });
+    });
+  } else if (pps > 1) {
+    // Pages per sheet: group visible pages into chunks, create composite
+    const PPS_COLS: Record<number, number> = { 2: 2, 4: 2, 6: 3, 9: 3, 16: 4 };
+    const cols = PPS_COLS[pps] ?? 2;
+
+    const visible: number[] = [];
+    for (let p = 1; p <= totalPages; p++) {
+      if (pageRange === null || pageRange.has(p)) visible.push(p);
+    }
+    for (let i = 0; i < visible.length; i += pps) {
+      const chunk = visible.slice(i, i + pps);
+      while (chunk.length < pps) chunk.push(0); // pad with blanks
+      const img = buildComposite(chunk, cols, refW, refH);
+      addPreviewPage(img, refW, refH);
+    }
+  } else {
+    // Single page per sheet
+    for (let p = 1; p <= totalPages; p++) {
+      if (pageRange !== null && !pageRange.has(p)) continue;
+      const { img, naturalW, naturalH } = pageData[p - 1];
+      const clone = new Image();
+      clone.src = img.src;
+      addPreviewPage(clone, naturalW, naturalH);
+    }
+  }
+
+  updateGreyscale();
 }
 
 function updateGreyscale() {
@@ -52,33 +203,49 @@ function updateGreyscale() {
   previewArea.classList.toggle('greyscale', grey);
 }
 
-function updateScale() {
-  const fit = selScale.value === 'fit';
-  document.querySelectorAll('.print-page').forEach(el => el.classList.toggle('fit', fit));
-}
-
-selPages.addEventListener('change', () => {
-  inpPagesCustom.classList.toggle('hidden', selPages.value !== 'custom');
-  updatePageVisibility();
+// ── Event wiring ──────────────────────────────────────────────
+inpPages.addEventListener('input',    renderPreview);
+selPps.addEventListener('change',     () => { if (!chkBooklet.checked) renderPreview(); });
+chkBooklet.addEventListener('change', () => {
+  if (chkBooklet.checked) {
+    selPps.value    = '2';
+    selDuplex.value = 'shortEdge';
+    selPps.disabled = true;
+  } else {
+    selPps.value    = '1';
+    selDuplex.value = 'simplex';
+    selPps.disabled = false;
+  }
+  renderPreview();
 });
-inpPagesCustom.addEventListener('input', updatePageVisibility);
 document.querySelectorAll('input[name="color"]').forEach(el =>
   el.addEventListener('change', updateGreyscale));
-selScale.addEventListener('change', updateScale);
 
 btnClose.addEventListener('click', () => window.close());
 
 btnPrint.addEventListener('click', async () => {
-  const copies   = Math.max(1, parseInt(inpCopies.value) || 1);
-  const grey     = (document.querySelector('input[name="color"]:checked') as HTMLInputElement)?.value === 'grey';
-  const scaleVal = selScale.value;
-  const scaleFactor = scaleVal === 'fit' || scaleVal === '100' ? 100 : parseInt(scaleVal);
+  const copies      = Math.max(1, parseInt(inpCopies.value) || 1);
+  const grey        = (document.querySelector('input[name="color"]:checked') as HTMLInputElement)?.value === 'grey';
+  const scaleVal    = selScale.value;
+  const scaleFactor = (scaleVal === 'fit' || scaleVal === '100') ? 100 : parseInt(scaleVal);
+  const duplexMode  = selDuplex.value as 'simplex' | 'longEdge' | 'shortEdge';
+  const landscape   = chkBooklet.checked; // booklet composites are landscape
 
   btnPrint.disabled = true;
-  await window.api.executePrint({ copies, color: !grey, scaleFactor });
-  btnPrint.disabled = false;
+  statusEl.textContent = 'Printing…';
+  await window.api.executePrint({
+    deviceName: selPrinter.value,
+    copies,
+    color:      !grey,
+    collate:    chkCollate.checked,
+    duplexMode,
+    scaleFactor,
+    landscape,
+  });
+  window.close();
 });
 
+// ── Receive PDF data from main ─────────────────────────────────
 window.api.onPdfData(async ({ buffer }) => {
   statusEl.textContent = 'Rendering pages…';
   const bytes  = new Uint8Array(buffer);
@@ -93,17 +260,18 @@ window.api.onPdfData(async ({ buffer }) => {
     canvas.height  = viewport.height;
     await page.render({ canvasContext: canvas.getContext('2d')!, viewport }).promise;
 
-    const img   = new Image();
-    img.src     = canvas.toDataURL('image/png');
-    img.style.cssText = `width: ${viewport.width / 1.5}px; height: auto;`;
+    const dataUrl  = canvas.toDataURL('image/png');
+    const img      = new Image();
+    await new Promise<void>(resolve => { img.onload = () => resolve(); img.src = dataUrl; });
 
-    const wrapper       = document.createElement('div');
-    wrapper.className   = 'print-page fit'; // fit is default
-    wrapper.dataset.page = String(pageNum);
-    wrapper.appendChild(img);
-    previewArea.appendChild(wrapper);
+    pageData.push({
+      img,
+      naturalW: viewport.width  / 1.5,
+      naturalH: viewport.height / 1.5,
+    });
+    statusEl.textContent = `Rendering… ${pageNum}/${totalPages}`;
   }
 
   statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;
-  updateScale(); // apply initial scale state
+  renderPreview();
 });

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -179,7 +179,6 @@ function addPreviewPage(imgEl: HTMLImageElement, displayW: number, displayH: num
   imgEl.style.cssText = `width:${scaledW}px; height:${scaledH}px; max-width:100%;`;
   const wrapper = document.createElement('div');
   wrapper.className = 'print-page';
-  if (displayW > displayH) wrapper.classList.add('landscape');
   wrapper.appendChild(imgEl);
   previewArea.appendChild(wrapper);
 }

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -17,6 +17,7 @@ interface Window {
     onCloseTabByFilepath: (callback: (filePath: string) => void) => void;
     copyFileToClipboard: (filePath: string) => Promise<{ ok: boolean }>;
     revealInExplorer:    (filePath: string) => Promise<{ ok: boolean }>;
+    printPdf:            (filePath: string) => Promise<{ ok: boolean; error?: string }>;
     startDrag: (filePath: string) => void;
     setUiZoom: (factor: number) => void;
     getUiZoom: () => number;

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -17,7 +17,9 @@ interface Window {
     onCloseTabByFilepath: (callback: (filePath: string) => void) => void;
     copyFileToClipboard: (filePath: string) => Promise<{ ok: boolean }>;
     revealInExplorer:    (filePath: string) => Promise<{ ok: boolean }>;
-    printPdf:            (filePath: string) => Promise<{ ok: boolean; error?: string }>;
+    openPrintPreview: (filePath: string) => Promise<{ ok: boolean; error?: string }>;
+    onPdfData: (callback: (data: { buffer: ArrayBuffer }) => void) => void;
+    executePrint: (options: { copies: number; color: boolean; scaleFactor: number }) => Promise<{ ok: boolean; error?: string }>;
     startDrag: (filePath: string) => void;
     setUiZoom: (factor: number) => void;
     getUiZoom: () => number;

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -17,9 +17,19 @@ interface Window {
     onCloseTabByFilepath: (callback: (filePath: string) => void) => void;
     copyFileToClipboard: (filePath: string) => Promise<{ ok: boolean }>;
     revealInExplorer:    (filePath: string) => Promise<{ ok: boolean }>;
-    openPrintPreview: (filePath: string) => Promise<{ ok: boolean; error?: string }>;
-    onPdfData: (callback: (data: { buffer: ArrayBuffer }) => void) => void;
-    executePrint: (options: { copies: number; color: boolean; scaleFactor: number }) => Promise<{ ok: boolean; error?: string }>;
+    openPrintPreview:       (filePath: string)                                         => Promise<{ ok: boolean; error?: string }>;
+    onPdfData:              (callback: (data: { buffer: ArrayBuffer }) => void)        => void;
+    getPrinters:            ()                                                          => Promise<{ name: string; isDefault: boolean }[]>;
+    openPrinterPreferences: (printerName: string)                                      => Promise<{ ok: boolean }>;
+    executePrint: (options: {
+      deviceName:  string;
+      copies:      number;
+      color:       boolean;
+      collate:     boolean;
+      duplexMode:  string;
+      scaleFactor: number;
+      landscape:   boolean;
+    }) => Promise<{ ok: boolean; error?: string }>;
     startDrag: (filePath: string) => void;
     setUiZoom: (factor: number) => void;
     getUiZoom: () => number;


### PR DESCRIPTION
## Summary

Replaces the broken `window.print()` approach (which produced blank output and wrong page counts) with a dedicated print preview window.

- **Root cause of #51**: `window.print()` on a canvas element produces blank output in Chromium's print path; the inline pixel dimensions set at the current zoom level also caused pages to span multiple sheets
- **Fix**: PDF pages are rendered via PDF.js into `<img>` elements (PNG data URLs) in a visible BrowserWindow — images print reliably where canvases do not

### New features
- Full print preview window with live page rendering
- Printer selection with Printer Preferences button
- Copies and collate
- Page range (e.g. `1`, `1-3`, `1,3,5`) — invalid or out-of-range entries show an empty preview
- Scale (fit to page, 100%, 75%, 50%, 25%)
- Portrait / Landscape orientation toggle — preview letterboxes content to match what will be printed
- Colour / Greyscale toggle
- Two-sided (duplex) printing
- Pages per sheet (1, 2, 4, 6, 9, 16) with composite canvas layout
- Booklet mode (pages reordered for fold-and-staple, short-edge duplex)
- Preview zoom via +/− toolbar buttons and Ctrl+scroll — auto fit-to-width on open and orientation change
- Print added to File menu (Ctrl+P)

### Error handling
- Print failure restores the Print button and shows an error in the status bar
- PDF load and page render errors are caught and displayed
- Print button disabled when no printers are installed
- Printer name validated against the live printer list before opening preferences

### Unsaved annotations
- Printing a document with unsaved annotations prompts to save first so annotations appear in the output
- Save confirmation dialog, combining-with-unsaved dialog, and print-with-unsaved dialog all use the app's custom modal style instead of native OS dialogs

Fixes #51

## Test plan

- [x] Open a single-page PDF and click Print — preview shows 1 page, status shows "1 page"
- [x] Open a multi-page PDF — all pages render in order, page count is correct
- [x] Page range: enter `2`, `1-3`, `1,3,5`, `999` (should show nothing), `3-1` (should show nothing)
- [x] Copies = 3 with Collate on and off — verify collation behaviour
- [x] Pages per sheet: try 2, 4, 6 on a multi-page document
- [x] Booklet mode: enable on a 6-page doc — 2 landscape composite sheets, pages in booklet order
- [x] Greyscale toggle updates the preview immediately without re-rendering
- [x] Switch orientation Portrait ↔ Landscape — preview updates and zoom fits to width
- [x] Preview zoom: +/− buttons, Ctrl+scroll
- [x] Print with unsaved annotations — prompted to save; annotations appear in output
- [x] Save confirmation uses custom dark modal (no native OS dialog)
- [ ] Print button is disabled when no printers are found
- [x] Close preview mid-render — no crash