### PR TITLE
Add Remove Pages, Footer, and Watermark tools

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -887,7 +887,7 @@ html, body {
   font-size: 12px;
 }
 .footer-col select { cursor: pointer; }
-.footer-custom-hidden { display: none; }
+.footer-custom-hidden { visibility: hidden; }
 .footer-size-row {
   display: flex;
   align-items: center;

--- a/assets/style.css
+++ b/assets/style.css
@@ -927,14 +927,17 @@ html, body {
 }
 .wm-row label { width: 72px; color: #999; flex-shrink: 0; }
 .wm-row input[type="text"],
-.wm-row input[type="number"] {
+.wm-row input[type="number"],
+.wm-row textarea {
   padding: 5px 7px;
   background: #2a2a2a;
   border: 1px solid var(--border);
   border-radius: 3px;
   color: var(--text);
   font-size: 12px;
+  font-family: inherit;
 }
+.wm-row textarea { min-height: 52px; }
 .wm-row span { color: #999; }
 #watermark-opacity-val { min-width: 32px; text-align: right; color: var(--text); }
 #watermark-preview {

--- a/assets/style.css
+++ b/assets/style.css
@@ -865,6 +865,62 @@ html, body {
   line-height: 1;
 }
 .reorder-arrow:hover { background: var(--border); }
+.reorder-remove { color: #c55; }
+.reorder-remove:hover { color: #e33; background: var(--border); }
+
+/* ── Footer modal ────────────────────────────────────────────── */
+#footer-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.footer-col { display: flex; flex-direction: column; gap: 4px; }
+.footer-col label { font-size: 11px; color: #999; }
+.footer-col input {
+  padding: 5px 7px;
+  background: #2a2a2a;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text);
+  font-size: 12px;
+}
+.footer-size-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #999;
+}
+.footer-size-row input {
+  padding: 4px 6px;
+  background: #2a2a2a;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text);
+  font-size: 12px;
+}
+
+/* ── Watermark modal ─────────────────────────────────────────── */
+.wm-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 12px;
+}
+.wm-row label { width: 72px; color: #999; flex-shrink: 0; }
+.wm-row input[type="text"],
+.wm-row input[type="number"] {
+  padding: 5px 7px;
+  background: #2a2a2a;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text);
+  font-size: 12px;
+}
+.wm-row span { color: #999; }
+#watermark-opacity-val { min-width: 32px; text-align: right; color: var(--text); }
 
 /* ── Loading spinner ─────────────────────────────────────────── */
 .loading-overlay {

--- a/assets/style.css
+++ b/assets/style.css
@@ -877,7 +877,8 @@ html, body {
 }
 .footer-col { display: flex; flex-direction: column; gap: 4px; }
 .footer-col label { font-size: 11px; color: #999; }
-.footer-col input {
+.footer-col select,
+.footer-col input[type="text"] {
   padding: 5px 7px;
   background: #2a2a2a;
   border: 1px solid var(--border);
@@ -885,12 +886,15 @@ html, body {
   color: var(--text);
   font-size: 12px;
 }
+.footer-col select { cursor: pointer; }
+.footer-custom-hidden { display: none; }
 .footer-size-row {
   display: flex;
   align-items: center;
   gap: 6px;
   font-size: 12px;
   color: #999;
+  margin-bottom: 10px;
 }
 .footer-size-row input {
   padding: 4px 6px;
@@ -900,8 +904,20 @@ html, body {
   color: var(--text);
   font-size: 12px;
 }
+#footer-preview {
+  display: block;
+  width: 100%;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+}
 
 /* ── Watermark modal ─────────────────────────────────────────── */
+#watermark-modal-body {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+.wm-fields { flex: 1; min-width: 0; }
 .wm-row {
   display: flex;
   align-items: center;
@@ -921,6 +937,11 @@ html, body {
 }
 .wm-row span { color: #999; }
 #watermark-opacity-val { min-width: 32px; text-align: right; color: var(--text); }
+#watermark-preview {
+  flex-shrink: 0;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+}
 
 /* ── Loading spinner ─────────────────────────────────────────── */
 .loading-overlay {

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -421,7 +421,7 @@
         <div class="wm-fields">
           <div class="wm-row">
             <label for="watermark-text">Text</label>
-            <input id="watermark-text" type="text" placeholder="e.g. DRAFT" style="flex:1;" />
+            <textarea id="watermark-text" rows="3" placeholder="e.g. DRAFT&#10;CONFIDENTIAL" style="flex:1;resize:vertical;"></textarea>
           </div>
           <div class="wm-row">
             <label for="watermark-fontsize">Font size</label>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -259,6 +259,23 @@
           </svg>
           Reorder Pages
         </button>
+        <button id="btn-footer" class="tool-panel-btn">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="3" y1="20" x2="21" y2="20"/>
+            <line x1="3" y1="15" x2="8"  y2="15"/>
+            <line x1="10" y1="15" x2="14" y2="15"/>
+            <line x1="16" y1="15" x2="21" y2="15"/>
+          </svg>
+          Add Footer
+        </button>
+        <button id="btn-watermark" class="tool-panel-btn">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+            <path d="M2 17l10 5 10-5"/>
+            <path d="M2 12l10 5 10-5"/>
+          </svg>
+          Add Watermark
+        </button>
       </div>
 
       <!-- Drag handle on right edge -->
@@ -329,13 +346,79 @@
   <div id="reorder-modal" class="modal-overlay hidden">
     <div class="modal-box" style="min-width:560px;">
       <div class="modal-title">Reorder Pages</div>
-      <p class="modal-hint">Drag page thumbnails to reorder them.</p>
+      <p class="modal-hint">Drag thumbnails to reorder, or use the arrows. Click &times; to remove a page.</p>
       <div class="modal-body">
         <div id="reorder-pages"></div>
       </div>
       <div class="modal-footer">
         <button class="modal-btn" id="reorder-cancel">Cancel</button>
         <button class="modal-btn primary" id="reorder-ok">Apply</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Footer modal ─────────────────────────────────────────── -->
+  <div id="footer-modal" class="modal-overlay hidden">
+    <div class="modal-box" style="min-width:480px;">
+      <div class="modal-title">Add Footer</div>
+      <p class="modal-hint">Appears on every page. Use {page} and {total} for page numbers.</p>
+      <div class="modal-body">
+        <div id="footer-cols">
+          <div class="footer-col">
+            <label for="footer-left">Left</label>
+            <input id="footer-left" type="text" placeholder="e.g. {page} / {total}" />
+          </div>
+          <div class="footer-col">
+            <label for="footer-center">Center</label>
+            <input id="footer-center" type="text" placeholder="Centered text" />
+          </div>
+          <div class="footer-col">
+            <label for="footer-right">Right</label>
+            <input id="footer-right" type="text" placeholder="Right-aligned text" />
+          </div>
+        </div>
+        <div class="footer-size-row">
+          <label for="footer-fontsize">Font size</label>
+          <input id="footer-fontsize" type="number" value="10" min="4" max="72" style="width:60px;" />
+          <span>pt</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="modal-btn" id="footer-cancel">Cancel</button>
+        <button class="modal-btn primary" id="footer-ok">Apply</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Watermark modal ───────────────────────────────────────── -->
+  <div id="watermark-modal" class="modal-overlay hidden">
+    <div class="modal-box" style="min-width:360px;">
+      <div class="modal-title">Add Watermark</div>
+      <p class="modal-hint">Embedded permanently into the PDF.</p>
+      <div class="modal-body">
+        <div class="wm-row">
+          <label for="watermark-text">Text</label>
+          <input id="watermark-text" type="text" placeholder="e.g. DRAFT" style="flex:1;" />
+        </div>
+        <div class="wm-row">
+          <label for="watermark-fontsize">Font size</label>
+          <input id="watermark-fontsize" type="number" value="72" min="8" max="400" style="width:70px;" />
+          <span>pt</span>
+        </div>
+        <div class="wm-row">
+          <label for="watermark-opacity">Opacity</label>
+          <input id="watermark-opacity" type="range" min="5" max="100" value="30" style="flex:1;" />
+          <span id="watermark-opacity-val">30%</span>
+        </div>
+        <div class="wm-row">
+          <label for="watermark-angle">Angle</label>
+          <input id="watermark-angle" type="number" value="45" min="0" max="360" style="width:70px;" />
+          <span>&#176;</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="modal-btn" id="watermark-cancel">Cancel</button>
+        <button class="modal-btn primary" id="watermark-ok">Apply</button>
       </div>
     </div>
   </div>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -361,20 +361,41 @@
   <div id="footer-modal" class="modal-overlay hidden">
     <div class="modal-box" style="min-width:480px;">
       <div class="modal-title">Add Footer</div>
-      <p class="modal-hint">Appears on every page. Use {page} and {total} for page numbers.</p>
+      <p class="modal-hint">Embedded permanently on every page.</p>
       <div class="modal-body">
         <div id="footer-cols">
           <div class="footer-col">
-            <label for="footer-left">Left</label>
-            <input id="footer-left" type="text" placeholder="e.g. {page} / {total}" />
+            <label for="footer-left-sel">Left</label>
+            <select id="footer-left-sel">
+              <option value="">None</option>
+              <option value="date">Date</option>
+              <option value="page">Page number</option>
+              <option value="page-total">Page / Total</option>
+              <option value="custom">Custom&hellip;</option>
+            </select>
+            <input id="footer-left-custom" class="footer-custom footer-custom-hidden" type="text" placeholder="Custom text" />
           </div>
           <div class="footer-col">
-            <label for="footer-center">Center</label>
-            <input id="footer-center" type="text" placeholder="Centered text" />
+            <label for="footer-center-sel">Center</label>
+            <select id="footer-center-sel">
+              <option value="">None</option>
+              <option value="date">Date</option>
+              <option value="page" selected>Page number</option>
+              <option value="page-total">Page / Total</option>
+              <option value="custom">Custom&hellip;</option>
+            </select>
+            <input id="footer-center-custom" class="footer-custom footer-custom-hidden" type="text" placeholder="Custom text" />
           </div>
           <div class="footer-col">
-            <label for="footer-right">Right</label>
-            <input id="footer-right" type="text" placeholder="Right-aligned text" />
+            <label for="footer-right-sel">Right</label>
+            <select id="footer-right-sel">
+              <option value="">None</option>
+              <option value="date">Date</option>
+              <option value="page">Page number</option>
+              <option value="page-total">Page / Total</option>
+              <option value="custom">Custom&hellip;</option>
+            </select>
+            <input id="footer-right-custom" class="footer-custom footer-custom-hidden" type="text" placeholder="Custom text" />
           </div>
         </div>
         <div class="footer-size-row">
@@ -382,6 +403,7 @@
           <input id="footer-fontsize" type="number" value="10" min="4" max="72" style="width:60px;" />
           <span>pt</span>
         </div>
+        <canvas id="footer-preview" width="440" height="140"></canvas>
       </div>
       <div class="modal-footer">
         <button class="modal-btn" id="footer-cancel">Cancel</button>
@@ -392,29 +414,32 @@
 
   <!-- ── Watermark modal ───────────────────────────────────────── -->
   <div id="watermark-modal" class="modal-overlay hidden">
-    <div class="modal-box" style="min-width:360px;">
+    <div class="modal-box" style="min-width:400px;">
       <div class="modal-title">Add Watermark</div>
       <p class="modal-hint">Embedded permanently into the PDF.</p>
-      <div class="modal-body">
-        <div class="wm-row">
-          <label for="watermark-text">Text</label>
-          <input id="watermark-text" type="text" placeholder="e.g. DRAFT" style="flex:1;" />
+      <div class="modal-body" id="watermark-modal-body">
+        <div class="wm-fields">
+          <div class="wm-row">
+            <label for="watermark-text">Text</label>
+            <input id="watermark-text" type="text" placeholder="e.g. DRAFT" style="flex:1;" />
+          </div>
+          <div class="wm-row">
+            <label for="watermark-fontsize">Font size</label>
+            <input id="watermark-fontsize" type="number" value="72" min="8" max="400" style="width:70px;" />
+            <span>pt</span>
+          </div>
+          <div class="wm-row">
+            <label for="watermark-opacity">Opacity</label>
+            <input id="watermark-opacity" type="range" min="5" max="100" value="30" style="flex:1;" />
+            <span id="watermark-opacity-val">30%</span>
+          </div>
+          <div class="wm-row">
+            <label for="watermark-angle">Angle</label>
+            <input id="watermark-angle" type="number" value="45" min="0" max="360" style="width:70px;" />
+            <span>&#176;</span>
+          </div>
         </div>
-        <div class="wm-row">
-          <label for="watermark-fontsize">Font size</label>
-          <input id="watermark-fontsize" type="number" value="72" min="8" max="400" style="width:70px;" />
-          <span>pt</span>
-        </div>
-        <div class="wm-row">
-          <label for="watermark-opacity">Opacity</label>
-          <input id="watermark-opacity" type="range" min="5" max="100" value="30" style="flex:1;" />
-          <span id="watermark-opacity-val">30%</span>
-        </div>
-        <div class="wm-row">
-          <label for="watermark-angle">Angle</label>
-          <input id="watermark-angle" type="number" value="45" min="0" max="360" style="width:70px;" />
-          <span>&#176;</span>
-        </div>
+        <canvas id="watermark-preview" width="120" height="155"></canvas>
       </div>
       <div class="modal-footer">
         <button class="modal-btn" id="watermark-cancel">Cancel</button>

--- a/src/renderer/annotator.ts
+++ b/src/renderer/annotator.ts
@@ -27,8 +27,7 @@ export class Annotator {
   _dragOrigAnn: Annotation | null;
   _dragPageRect: DOMRect | null;
   _clipboard: Annotation | null;
-  _history: string[];
-  _histIdx: number;
+  onCommit?: () => void;
   _handlers: Record<number, unknown>;
   _docMouseupHighlight!: (e: MouseEvent) => void;
   _docMousemoveDrag!: (e: MouseEvent) => void;
@@ -71,9 +70,6 @@ export class Annotator {
     this._lastCursorPageNum = null;
     this._lastCursorNorm    = null;
 
-    this._history = ['[]'];
-    this._histIdx = 0;
-
     this._handlers = {};
     this._attachAll();
   }
@@ -109,8 +105,6 @@ export class Annotator {
       const ctx = p.annotCanvas.getContext('2d')!;
       ctx.clearRect(0, 0, p.annotCanvas.width, p.annotCanvas.height);
     });
-    this._history = ['[]'];
-    this._histIdx = 0;
   }
 
   redrawAll() {
@@ -149,20 +143,9 @@ export class Annotator {
     }
   }
 
-  undo() {
-    if (this._histIdx <= 0) return;
-    this._histIdx--;
+  setAnnotations(json: string) {
     this._clearSelection(false);
-    const data = JSON.parse(this._history[this._histIdx]);
-    this.annotations.splice(0, this.annotations.length, ...data);
-    this.redrawAll();
-  }
-
-  redo() {
-    if (this._histIdx >= this._history.length - 1) return;
-    this._histIdx++;
-    this._clearSelection(false);
-    const data = JSON.parse(this._history[this._histIdx]);
+    const data = JSON.parse(json) as Annotation[];
     this.annotations.splice(0, this.annotations.length, ...data);
     this.redrawAll();
   }
@@ -988,8 +971,6 @@ export class Annotator {
   // ── Undo / redo history ──────────────────────────────────────
 
   _pushHistory() {
-    this._history.splice(this._histIdx + 1);
-    this._history.push(JSON.stringify([...this.annotations]));
-    this._histIdx++;
+    this.onCommit?.();
   }
 }

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1981,7 +1981,6 @@ async function _executeReorder() {
   pages.forEach(p => resultDoc.addPage(p));
   const bytes = await resultDoc.save();
 
-  _pushUndo(tab);
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   // Re-add loading overlay for the re-render
@@ -2106,7 +2105,6 @@ async function _executeFooter() {
   const tab   = activeTab;
   const bytes = await embedFooter(tab.pdfBytes, { left, center, right, fontSize });
 
-  _pushUndo(tab);
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   const reloadEl = document.createElement('div');
@@ -2196,7 +2194,6 @@ async function _executeWatermark() {
   const tab   = activeTab;
   const bytes = await embedWatermark(tab.pdfBytes, { text, fontSize, opacity, angle });
 
-  _pushUndo(tab);
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   const reloadEl = document.createElement('div');

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -845,6 +845,8 @@ async function _loadTabContent(tab: Tab) {
     tab.annotator = new Annotator(tab.viewer.pages, tab.viewer);
     _patchAnnotatorForDirty(tab);
     _pushUndo(tab);
+    // Mark the initial loaded state as clean (only on first open, not after PDF ops or undo).
+    if (tab._undoCleanIdx === undefined) tab._undoCleanIdx = tab._undoIdx!;
     tab.outline = await tab.viewer.getOutline();
   } catch (err) {
     const name = tab.filePath ? tab.filePath.split(/[\\/]/).pop() : 'file';
@@ -941,9 +943,10 @@ async function saveTab(tab: Tab | null) {
     if (choice !== 0) return false;
     const res = await window.api.saveFile(tab.filePath, bytes.buffer as ArrayBuffer);
     if (res.ok) {
-      tab.pdfBytes     = bytes;
-      tab._savedBytes  = null;
-      tab.dirty        = false;
+      tab.pdfBytes       = bytes;
+      tab._savedBytes    = null;
+      tab._undoCleanIdx  = tab._undoIdx ?? null;
+      tab.dirty          = false;
       renderTabBar();
       return true;
     } else if (res.error && res.error !== 'cancelled') {
@@ -963,6 +966,7 @@ async function saveTab(tab: Tab | null) {
     tab._suggestedName = null;
     tab.pdfBytes       = bytes;
     tab._savedBytes    = null;
+    tab._undoCleanIdx  = tab._undoIdx ?? null;
     tab.dirty          = false;
     renderTabBar();
     updateTitleBar(tab);
@@ -995,6 +999,7 @@ async function saveTabCopy(tab: Tab | null) {
     tab._suggestedDir  = null;
     tab._suggestedName = null;
     tab.pdfBytes       = bytes;
+    tab._undoCleanIdx  = tab._undoIdx ?? null;
     tab.dirty          = false;
     renderTabBar();
     updateTitleBar(tab);
@@ -1122,10 +1127,31 @@ function _pushUndo(tab: Tab): void {
   if (_undoing) return;
   const annotations = tab.annotator ? JSON.stringify(tab.annotator.annotations) : '[]';
   if (!tab._undoStack) { tab._undoStack = []; tab._undoIdx = -1; }
-  tab._undoStack.splice(tab._undoIdx! + 1);
+  // Truncate forward history. If the clean state is in the discarded future, mark it unreachable.
+  const nextIdx = tab._undoIdx! + 1;
+  if (tab._undoStack.length > nextIdx) {
+    if (tab._undoCleanIdx != null && tab._undoCleanIdx > tab._undoIdx!) tab._undoCleanIdx = null;
+    tab._undoStack.splice(nextIdx);
+  }
   tab._undoStack.push({ pdfBytes: tab.pdfBytes, annotations });
-  if (tab._undoStack.length > UNDO_LIMIT) tab._undoStack.shift();
+  // Enforce limit. If the oldest entry is dropped, shift the clean index down with it.
+  if (tab._undoStack.length > UNDO_LIMIT) {
+    tab._undoStack.shift();
+    if (tab._undoCleanIdx != null) {
+      tab._undoCleanIdx--;
+      if (tab._undoCleanIdx < 0) tab._undoCleanIdx = null; // clean entry was dropped
+    }
+  }
   tab._undoIdx = tab._undoStack.length - 1;
+}
+
+function _syncDirtyToUndo(tab: Tab): void {
+  if (tab._undoCleanIdx != null && tab._undoIdx === tab._undoCleanIdx) {
+    tab.dirty = false;
+    renderTabBar();
+  } else {
+    markDirty(tab);
+  }
 }
 
 async function _applyUndo(tab: Tab, entry: { pdfBytes: Uint8Array; annotations: string }): Promise<void> {
@@ -1149,7 +1175,7 @@ async function _applyUndo(tab: Tab, entry: { pdfBytes: Uint8Array; annotations: 
   } else {
     tab.annotator?.setAnnotations(entry.annotations);
   }
-  markDirty(tab);
+  _syncDirtyToUndo(tab);
 }
 
 // ── Zoom ───────────────────────────────────────────────────────

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1946,7 +1946,7 @@ function _drawFooterPreview() {
 
   // Footer text
   const pdfFontSize  = parseFloat((document.getElementById('footer-fontsize') as HTMLInputElement).value) || 10;
-  const canvasFontSize = Math.max(9, Math.min(16, pdfFontSize * pw / 280));
+  const canvasFontSize = pdfFontSize * pw / 612; // proportional to letter page width (612pt)
   ctx.font      = `${canvasFontSize}px Helvetica, Arial, sans-serif`;
   ctx.fillStyle = '#222222';
   const textY = sepY + 17;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -2028,12 +2028,15 @@ function _drawWatermarkPreview() {
   ctx.fillStyle = '#ffffff';
   ctx.fillRect(mx, my, pw, ph);
 
-  const text     = (document.getElementById('watermark-text')     as HTMLInputElement).value.trim() || 'Preview';
+  const rawText  = (document.getElementById('watermark-text')     as HTMLTextAreaElement).value;
   const pdfSize  = parseFloat((document.getElementById('watermark-fontsize') as HTMLInputElement).value) || 72;
   const opacity  = parseFloat((document.getElementById('watermark-opacity')  as HTMLInputElement).value) / 100;
   const angle    = parseFloat((document.getElementById('watermark-angle')    as HTMLInputElement).value) || 0;
+  const lines    = rawText.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+  const preview  = lines.length > 0 ? lines : ['Preview'];
 
-  const canvasFs = Math.max(6, Math.round(pdfSize * pw / 612));
+  const canvasFs   = Math.max(6, Math.round(pdfSize * pw / 612));
+  const lineHeight = canvasFs * 1.3;
 
   ctx.save();
   ctx.globalAlpha  = opacity;
@@ -2043,7 +2046,10 @@ function _drawWatermarkPreview() {
   ctx.textBaseline = 'middle';
   ctx.translate(mx + pw / 2, my + ph / 2);
   ctx.rotate(-angle * Math.PI / 180); // negative to match pdf-lib CCW convention
-  ctx.fillText(text, 0, 0);
+  preview.forEach((line, i) => {
+    const yOffset = (i - (preview.length - 1) / 2) * lineHeight;
+    ctx.fillText(line, 0, yOffset);
+  });
   ctx.restore();
 }
 
@@ -2063,7 +2069,7 @@ _wmOpacityInput.addEventListener('input', () => {
   _wmOpacityVal.textContent = _wmOpacityInput.value + '%';
   _drawWatermarkPreview();
 });
-(document.getElementById('watermark-text')     as HTMLInputElement).addEventListener('input',  _drawWatermarkPreview);
+(document.getElementById('watermark-text')     as HTMLTextAreaElement).addEventListener('input',  _drawWatermarkPreview);
 (document.getElementById('watermark-fontsize') as HTMLInputElement).addEventListener('input',  _drawWatermarkPreview);
 (document.getElementById('watermark-angle')    as HTMLInputElement).addEventListener('input',  _drawWatermarkPreview);
 (document.getElementById('watermark-angle')    as HTMLInputElement).addEventListener('change', _drawWatermarkPreview);
@@ -2072,7 +2078,8 @@ async function _executeWatermark() {
   if (!activeTab) return;
   document.getElementById('watermark-modal')!.classList.add('hidden');
 
-  const text     = (document.getElementById('watermark-text')     as HTMLInputElement).value.trim();
+  const text     = (document.getElementById('watermark-text')     as HTMLTextAreaElement).value
+                    .split('\n').map(l => l.trim()).filter(l => l.length > 0).join('\n');
   const fontSize = parseFloat((document.getElementById('watermark-fontsize') as HTMLInputElement).value) || 72;
   const opacity  = parseFloat((document.getElementById('watermark-opacity')  as HTMLInputElement).value) / 100;
   const angle    = parseFloat((document.getElementById('watermark-angle')    as HTMLInputElement).value) || 0;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1891,9 +1891,95 @@ async function _executeReorder() {
 
 // ── Add Footer ─────────────────────────────────────────────────
 
+function _resolveFooterColForPreview(col: 'left' | 'center' | 'right'): string {
+  const sel    = document.getElementById(`footer-${col}-sel`)    as HTMLSelectElement;
+  const custom = document.getElementById(`footer-${col}-custom`) as HTMLInputElement;
+  const total  = activeTab?.viewer.pageCount ?? 10;
+  switch (sel.value) {
+    case 'date':       return new Date().toLocaleDateString();
+    case 'page':       return '1';
+    case 'page-total': return `1 / ${total}`;
+    case 'custom':     return custom.value;
+    default:           return '';
+  }
+}
+
+function _resolveFooterColForEmbed(col: 'left' | 'center' | 'right'): string {
+  const sel    = document.getElementById(`footer-${col}-sel`)    as HTMLSelectElement;
+  const custom = document.getElementById(`footer-${col}-custom`) as HTMLInputElement;
+  switch (sel.value) {
+    case 'date':       return new Date().toLocaleDateString();
+    case 'page':       return '{page}';
+    case 'page-total': return '{page} / {total}';
+    case 'custom':     return custom.value;
+    default:           return '';
+  }
+}
+
+function _drawFooterPreview() {
+  const canvas = document.getElementById('footer-preview') as HTMLCanvasElement;
+  const ctx    = canvas.getContext('2d')!;
+  const W = canvas.width, H = canvas.height;
+
+  ctx.clearRect(0, 0, W, H);
+  ctx.fillStyle = '#1e1e1e';
+  ctx.fillRect(0, 0, W, H);
+
+  // Page outline
+  const mx = 16, my = 10, pw = W - mx * 2, ph = H - my * 2;
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(mx, my, pw, ph);
+
+  // Simulated content lines
+  ctx.strokeStyle = '#e0e0e0';
+  ctx.lineWidth = 1;
+  for (let y = my + 10; y < my + ph - 34; y += 10) {
+    const lw = y < my + ph - 54 ? pw - 24 : (pw - 24) * 0.55;
+    ctx.beginPath(); ctx.moveTo(mx + 12, y); ctx.lineTo(mx + 12 + lw, y); ctx.stroke();
+  }
+
+  // Footer separator
+  const sepY = my + ph - 28;
+  ctx.strokeStyle = '#c0c0c0';
+  ctx.lineWidth = 0.5;
+  ctx.beginPath(); ctx.moveTo(mx + 8, sepY); ctx.lineTo(mx + pw - 8, sepY); ctx.stroke();
+
+  // Footer text
+  const pdfFontSize  = parseFloat((document.getElementById('footer-fontsize') as HTMLInputElement).value) || 10;
+  const canvasFontSize = Math.max(9, Math.min(16, pdfFontSize * pw / 280));
+  ctx.font      = `${canvasFontSize}px Helvetica, Arial, sans-serif`;
+  ctx.fillStyle = '#222222';
+  const textY = sepY + 17;
+
+  const lText = _resolveFooterColForPreview('left');
+  const cText = _resolveFooterColForPreview('center');
+  const rText = _resolveFooterColForPreview('right');
+
+  if (lText) { ctx.textAlign = 'left';   ctx.fillText(lText, mx + 10,      textY); }
+  if (cText) { ctx.textAlign = 'center'; ctx.fillText(cText, mx + pw / 2,  textY); }
+  if (rText) { ctx.textAlign = 'right';  ctx.fillText(rText, mx + pw - 10, textY); }
+  ctx.textAlign = 'left';
+}
+
+function _setupFooterColSelect(col: 'left' | 'center' | 'right') {
+  const sel    = document.getElementById(`footer-${col}-sel`)    as HTMLSelectElement;
+  const custom = document.getElementById(`footer-${col}-custom`) as HTMLInputElement;
+  sel.addEventListener('change', () => {
+    custom.classList.toggle('footer-custom-hidden', sel.value !== 'custom');
+    _drawFooterPreview();
+  });
+  custom.addEventListener('input', _drawFooterPreview);
+}
+
+_setupFooterColSelect('left');
+_setupFooterColSelect('center');
+_setupFooterColSelect('right');
+(document.getElementById('footer-fontsize') as HTMLInputElement).addEventListener('input', _drawFooterPreview);
+
 document.getElementById('btn-footer')!.addEventListener('click', () => {
   if (!activeTab) return;
   document.getElementById('footer-modal')!.classList.remove('hidden');
+  _drawFooterPreview();
 });
 document.getElementById('footer-cancel')!.addEventListener('click', () => {
   document.getElementById('footer-modal')!.classList.add('hidden');
@@ -1904,9 +1990,9 @@ async function _executeFooter() {
   if (!activeTab) return;
   document.getElementById('footer-modal')!.classList.add('hidden');
 
-  const left     = (document.getElementById('footer-left')     as HTMLInputElement).value;
-  const center   = (document.getElementById('footer-center')   as HTMLInputElement).value;
-  const right    = (document.getElementById('footer-right')    as HTMLInputElement).value;
+  const left     = _resolveFooterColForEmbed('left');
+  const center   = _resolveFooterColForEmbed('center');
+  const right    = _resolveFooterColForEmbed('right');
   const fontSize = parseFloat((document.getElementById('footer-fontsize') as HTMLInputElement).value) || 10;
 
   if (!left && !center && !right) return;
@@ -1928,9 +2014,43 @@ async function _executeFooter() {
 
 // ── Add Watermark ───────────────────────────────────────────────
 
+function _drawWatermarkPreview() {
+  const canvas = document.getElementById('watermark-preview') as HTMLCanvasElement;
+  const ctx    = canvas.getContext('2d')!;
+  const W = canvas.width, H = canvas.height;
+
+  ctx.clearRect(0, 0, W, H);
+  ctx.fillStyle = '#1e1e1e';
+  ctx.fillRect(0, 0, W, H);
+
+  // Page outline
+  const mx = 8, my = 8, pw = W - mx * 2, ph = H - my * 2;
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(mx, my, pw, ph);
+
+  const text     = (document.getElementById('watermark-text')     as HTMLInputElement).value.trim() || 'Preview';
+  const pdfSize  = parseFloat((document.getElementById('watermark-fontsize') as HTMLInputElement).value) || 72;
+  const opacity  = parseFloat((document.getElementById('watermark-opacity')  as HTMLInputElement).value) / 100;
+  const angle    = parseFloat((document.getElementById('watermark-angle')    as HTMLInputElement).value) || 0;
+
+  const canvasFs = Math.max(6, Math.round(pdfSize * pw / 612));
+
+  ctx.save();
+  ctx.globalAlpha  = opacity;
+  ctx.fillStyle    = '#808080';
+  ctx.font         = `bold ${canvasFs}px Helvetica, Arial, sans-serif`;
+  ctx.textAlign    = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.translate(mx + pw / 2, my + ph / 2);
+  ctx.rotate(-angle * Math.PI / 180); // negative to match pdf-lib CCW convention
+  ctx.fillText(text, 0, 0);
+  ctx.restore();
+}
+
 document.getElementById('btn-watermark')!.addEventListener('click', () => {
   if (!activeTab) return;
   document.getElementById('watermark-modal')!.classList.remove('hidden');
+  _drawWatermarkPreview();
 });
 document.getElementById('watermark-cancel')!.addEventListener('click', () => {
   document.getElementById('watermark-modal')!.classList.add('hidden');
@@ -1939,7 +2059,14 @@ document.getElementById('watermark-ok')!.addEventListener('click', _executeWater
 
 const _wmOpacityInput = document.getElementById('watermark-opacity') as HTMLInputElement;
 const _wmOpacityVal   = document.getElementById('watermark-opacity-val')!;
-_wmOpacityInput.addEventListener('input', () => { _wmOpacityVal.textContent = _wmOpacityInput.value + '%'; });
+_wmOpacityInput.addEventListener('input', () => {
+  _wmOpacityVal.textContent = _wmOpacityInput.value + '%';
+  _drawWatermarkPreview();
+});
+(document.getElementById('watermark-text')     as HTMLInputElement).addEventListener('input',  _drawWatermarkPreview);
+(document.getElementById('watermark-fontsize') as HTMLInputElement).addEventListener('input',  _drawWatermarkPreview);
+(document.getElementById('watermark-angle')    as HTMLInputElement).addEventListener('input',  _drawWatermarkPreview);
+(document.getElementById('watermark-angle')    as HTMLInputElement).addEventListener('change', _drawWatermarkPreview);
 
 async function _executeWatermark() {
   if (!activeTab) return;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -10,7 +10,7 @@ import type * as PDFLibNS from 'pdf-lib';
 import type { OutlineNode } from './types.js';
 const { PDFDocument } = _pdfLib as unknown as typeof PDFLibNS;
 import { FindBar }          from './find.js';
-import type { Tab, CloseContext } from './types.js';
+import type { Tab, CloseContext, Annotation } from './types.js';
 
 // ── State ──────────────────────────────────────────────────────
 
@@ -844,6 +844,7 @@ async function _loadTabContent(tab: Tab) {
     await tab.viewer.load(tab.pdfBytes);
     tab.annotator = new Annotator(tab.viewer.pages, tab.viewer);
     _patchAnnotatorForDirty(tab);
+    _pushUndo(tab);
     tab.outline = await tab.viewer.getOutline();
   } catch (err) {
     const name = tab.filePath ? tab.filePath.split(/[\\/]/).pop() : 'file';
@@ -1109,6 +1110,46 @@ function _patchAnnotatorForDirty(tab: Tab) {
     },
   });
   tab.annotator!.annotations = proxy;
+  tab.annotator!.onCommit = () => _pushUndo(tab);
+}
+
+// ── Unified undo / redo ────────────────────────────────────────
+
+const UNDO_LIMIT = 20;
+let _undoing = false;
+
+function _pushUndo(tab: Tab): void {
+  if (_undoing) return;
+  const annotations = tab.annotator ? JSON.stringify(tab.annotator.annotations) : '[]';
+  if (!tab._undoStack) { tab._undoStack = []; tab._undoIdx = -1; }
+  tab._undoStack.splice(tab._undoIdx! + 1);
+  tab._undoStack.push({ pdfBytes: tab.pdfBytes, annotations });
+  if (tab._undoStack.length > UNDO_LIMIT) tab._undoStack.shift();
+  tab._undoIdx = tab._undoStack.length - 1;
+}
+
+async function _applyUndo(tab: Tab, entry: { pdfBytes: Uint8Array; annotations: string }): Promise<void> {
+  const prevBytes = tab.pdfBytes;
+  tab.pdfBytes = entry.pdfBytes;
+  if (entry.pdfBytes !== prevBytes) {
+    const scrollTop = tab.pane.scrollTop;
+    const reloadEl = document.createElement('div');
+    reloadEl.className = 'loading-overlay';
+    reloadEl.innerHTML = '<div class="spinner"></div>';
+    tab.pane.appendChild(reloadEl);
+    tab.loadingEl = reloadEl;
+    finder.invalidateTab(tab);
+    await _loadTabContent(tab);
+    const data = JSON.parse(entry.annotations) as Annotation[];
+    if (data.length > 0) {
+      tab.annotator!.annotations.splice(0, tab.annotator!.annotations.length, ...data);
+      tab.annotator!.redrawAll();
+    }
+    requestAnimationFrame(() => { tab.pane.scrollTop = scrollTop; });
+  } else {
+    tab.annotator?.setAnnotations(entry.annotations);
+  }
+  markDirty(tab);
 }
 
 // ── Zoom ───────────────────────────────────────────────────────
@@ -1395,8 +1436,25 @@ document.querySelectorAll('.swatch').forEach(s => {
   });
 });
 
-document.getElementById('btn-undo')!.addEventListener('click',   () => activeTab?.annotator?.undo());
-document.getElementById('btn-redo')!.addEventListener('click',   () => activeTab?.annotator?.redo());
+document.getElementById('btn-undo')!.addEventListener('click', async () => {
+  if (_undoing) return;
+  const tab = activeTab;
+  if (!tab?._undoStack || (tab._undoIdx ?? -1) <= 0) return;
+  const idx = tab._undoIdx!;
+  tab._undoIdx = idx - 1;
+  _undoing = true;
+  try { await _applyUndo(tab, tab._undoStack[idx - 1]); } finally { _undoing = false; }
+});
+document.getElementById('btn-redo')!.addEventListener('click', async () => {
+  if (_undoing) return;
+  const tab = activeTab;
+  if (!tab?._undoStack) return;
+  const idx = tab._undoIdx ?? -1;
+  if (idx >= tab._undoStack.length - 1) return;
+  tab._undoIdx = idx + 1;
+  _undoing = true;
+  try { await _applyUndo(tab, tab._undoStack[idx + 1]); } finally { _undoing = false; }
+});
 document.getElementById('btn-fit')!.addEventListener('click',    fitWidth);
 document.getElementById('btn-fit-h')!.addEventListener('click',  fitHeight);
 document.getElementById('btn-rotate')!.addEventListener('click', (e) => rotate(e.shiftKey));
@@ -1454,8 +1512,29 @@ document.addEventListener('keydown', async (e) => {
   if (ctrl && e.key === '0') { e.preventDefault(); fitWidth(); return; }
   if (document.activeElement?.tagName === 'INPUT' || document.activeElement?.tagName === 'TEXTAREA') return;
 
-  if (ctrl && e.key === 'z') { e.preventDefault(); activeTab?.annotator?.undo(); return; }
-  if (ctrl && (e.key === 'y' || (e.shiftKey && e.key === 'Z'))) { e.preventDefault(); activeTab?.annotator?.redo(); return; }
+  if (ctrl && e.key === 'z') {
+    e.preventDefault();
+    if (_undoing) return;
+    const tab = activeTab;
+    if (!tab?._undoStack || (tab._undoIdx ?? -1) <= 0) return;
+    const idx = tab._undoIdx!;
+    tab._undoIdx = idx - 1;
+    _undoing = true;
+    try { await _applyUndo(tab, tab._undoStack[idx - 1]); } finally { _undoing = false; }
+    return;
+  }
+  if (ctrl && (e.key === 'y' || (e.shiftKey && e.key === 'Z'))) {
+    e.preventDefault();
+    if (_undoing) return;
+    const tab = activeTab;
+    if (!tab?._undoStack) return;
+    const idx = tab._undoIdx ?? -1;
+    if (idx >= tab._undoStack.length - 1) return;
+    tab._undoIdx = idx + 1;
+    _undoing = true;
+    try { await _applyUndo(tab, tab._undoStack[idx + 1]); } finally { _undoing = false; }
+    return;
+  }
   if (ctrl && e.key === 'x') { e.preventDefault(); activeTab?.annotator?.cut(); return; }
   if (ctrl && e.key === 'v') { e.preventDefault(); activeTab?.annotator?.paste(); return; }
   if (ctrl && e.key === 'c') {
@@ -1876,6 +1955,7 @@ async function _executeReorder() {
   pages.forEach(p => resultDoc.addPage(p));
   const bytes = await resultDoc.save();
 
+  _pushUndo(tab);
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   // Re-add loading overlay for the re-render
@@ -2000,6 +2080,7 @@ async function _executeFooter() {
   const tab   = activeTab;
   const bytes = await embedFooter(tab.pdfBytes, { left, center, right, fontSize });
 
+  _pushUndo(tab);
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   const reloadEl = document.createElement('div');
@@ -2089,6 +2170,7 @@ async function _executeWatermark() {
   const tab   = activeTab;
   const bytes = await embedWatermark(tab.pdfBytes, { text, fontSize, opacity, angle });
 
+  _pushUndo(tab);
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   const reloadEl = document.createElement('div');

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -3,7 +3,7 @@
 
 import { PDFViewer }        from './viewer.js';
 import { Annotator }        from './annotator.js';
-import { embedAnnotations } from './saver.js';
+import { embedAnnotations, embedFooter, embedWatermark } from './saver.js';
 // @ts-expect-error — pdf-lib is imported via direct path for Electron's file:// ESM loader
 import * as _pdfLib       from '../../node_modules/pdf-lib/dist/pdf-lib.esm.js';
 import type * as PDFLibNS from 'pdf-lib';
@@ -1798,7 +1798,11 @@ async function _openReorderModal() {
     btnR.className = 'reorder-arrow';
     btnR.title     = 'Move right';
     btnR.innerHTML = '&#8594;';
-    controls.append(btnL, btnR);
+    const btnDel = document.createElement('button');
+    btnDel.className = 'reorder-arrow reorder-remove';
+    btnDel.title     = 'Remove page';
+    btnDel.innerHTML = '&#x2715;';
+    controls.append(btnL, btnR, btnDel);
 
     thumb.append(img, num, controls);
 
@@ -1810,6 +1814,13 @@ async function _openReorderModal() {
 
     btnL.addEventListener('click', (e) => { e.stopPropagation(); selectThumb(thumb); moveThumb(thumb, -1); });
     btnR.addEventListener('click', (e) => { e.stopPropagation(); selectThumb(thumb); moveThumb(thumb,  1); });
+    btnDel.addEventListener('click', (e) => {
+      e.stopPropagation();
+      thumb.remove();
+      container.querySelectorAll('.reorder-page-num').forEach((s, i) => {
+        s.textContent = `Page ${i + 1}`;
+      });
+    });
 
     thumb.addEventListener('dragstart', (e) => {
       e.dataTransfer!.setData('reorder-orig', String(thumb.dataset.orig));
@@ -1851,11 +1862,14 @@ async function _executeReorder() {
   if (!activeTab) return;
   document.getElementById('reorder-modal')!.classList.add('hidden');
 
+  const tab       = activeTab;
   const container = document.getElementById('reorder-pages')!;
   const newOrder  = [...container.querySelectorAll('.reorder-thumb')].map(el => Number((el as HTMLElement).dataset.orig));
-  if (newOrder.every((v, i) => v === i)) return; // unchanged
-
-  const tab = activeTab;
+  if (newOrder.length === 0) {
+    await showDialog({ title: 'Remove Pages', message: 'Cannot remove all pages.', buttons: ['OK'], defaultId: 0, cancelId: 0 });
+    return;
+  }
+  if (newOrder.length === tab.viewer.pageCount && newOrder.every((v, i) => v === i)) return; // unchanged
   const srcDoc    = await PDFDocument.load(tab.pdfBytes, { ignoreEncryption: true });
   const resultDoc = await PDFDocument.create();
   const pages     = await resultDoc.copyPages(srcDoc, newOrder);
@@ -1865,6 +1879,84 @@ async function _executeReorder() {
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   // Re-add loading overlay for the re-render
+  const reloadEl = document.createElement('div');
+  reloadEl.className = 'loading-overlay';
+  reloadEl.innerHTML = '<div class="spinner"></div>';
+  tab.pane.appendChild(reloadEl);
+  tab.loadingEl = reloadEl;
+  finder.invalidateTab(tab);
+  await _loadTabContent(tab);
+  markDirty(tab);
+}
+
+// ── Add Footer ─────────────────────────────────────────────────
+
+document.getElementById('btn-footer')!.addEventListener('click', () => {
+  if (!activeTab) return;
+  document.getElementById('footer-modal')!.classList.remove('hidden');
+});
+document.getElementById('footer-cancel')!.addEventListener('click', () => {
+  document.getElementById('footer-modal')!.classList.add('hidden');
+});
+document.getElementById('footer-ok')!.addEventListener('click', _executeFooter);
+
+async function _executeFooter() {
+  if (!activeTab) return;
+  document.getElementById('footer-modal')!.classList.add('hidden');
+
+  const left     = (document.getElementById('footer-left')     as HTMLInputElement).value;
+  const center   = (document.getElementById('footer-center')   as HTMLInputElement).value;
+  const right    = (document.getElementById('footer-right')    as HTMLInputElement).value;
+  const fontSize = parseFloat((document.getElementById('footer-fontsize') as HTMLInputElement).value) || 10;
+
+  if (!left && !center && !right) return;
+
+  const tab   = activeTab;
+  const bytes = await embedFooter(tab.pdfBytes, { left, center, right, fontSize });
+
+  tab.pdfBytes = bytes;
+  tab.annotator!.clear();
+  const reloadEl = document.createElement('div');
+  reloadEl.className = 'loading-overlay';
+  reloadEl.innerHTML = '<div class="spinner"></div>';
+  tab.pane.appendChild(reloadEl);
+  tab.loadingEl = reloadEl;
+  finder.invalidateTab(tab);
+  await _loadTabContent(tab);
+  markDirty(tab);
+}
+
+// ── Add Watermark ───────────────────────────────────────────────
+
+document.getElementById('btn-watermark')!.addEventListener('click', () => {
+  if (!activeTab) return;
+  document.getElementById('watermark-modal')!.classList.remove('hidden');
+});
+document.getElementById('watermark-cancel')!.addEventListener('click', () => {
+  document.getElementById('watermark-modal')!.classList.add('hidden');
+});
+document.getElementById('watermark-ok')!.addEventListener('click', _executeWatermark);
+
+const _wmOpacityInput = document.getElementById('watermark-opacity') as HTMLInputElement;
+const _wmOpacityVal   = document.getElementById('watermark-opacity-val')!;
+_wmOpacityInput.addEventListener('input', () => { _wmOpacityVal.textContent = _wmOpacityInput.value + '%'; });
+
+async function _executeWatermark() {
+  if (!activeTab) return;
+  document.getElementById('watermark-modal')!.classList.add('hidden');
+
+  const text     = (document.getElementById('watermark-text')     as HTMLInputElement).value.trim();
+  const fontSize = parseFloat((document.getElementById('watermark-fontsize') as HTMLInputElement).value) || 72;
+  const opacity  = parseFloat((document.getElementById('watermark-opacity')  as HTMLInputElement).value) / 100;
+  const angle    = parseFloat((document.getElementById('watermark-angle')    as HTMLInputElement).value) || 0;
+
+  if (!text) return;
+
+  const tab   = activeTab;
+  const bytes = await embedWatermark(tab.pdfBytes, { text, fontSize, opacity, angle });
+
+  tab.pdfBytes = bytes;
+  tab.annotator!.clear();
   const reloadEl = document.createElement('div');
   reloadEl.className = 'loading-overlay';
   reloadEl.innerHTML = '<div class="spinner"></div>';

--- a/src/renderer/saver.ts
+++ b/src/renderer/saver.ts
@@ -9,7 +9,7 @@ import type { Annotation, DrawAnnotation, HighlightAnnotation, TextAnnotation, S
 import type { PDFViewer } from './viewer.js';
 
 // Cast the direct-path runtime import to the pdf-lib type surface
-const { PDFDocument, PDFName, PDFArray, PDFNumber, PDFString, degrees } =
+const { PDFDocument, PDFName, PDFArray, PDFNumber, PDFString, degrees, rgb, StandardFonts } =
   _pdfLib as unknown as typeof PDFLibNS;
 
 type PDFDoc  = import('pdf-lib').PDFDocument;
@@ -255,13 +255,105 @@ function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: numb
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _appendAnnotation(pdfPage: PDFPage, annotDict: any): void {
-   
+
   const ref    = pdfPage.doc.context.register(annotDict);
   const annots = pdfPage.node.get(PDFName.of('Annots'));
   if (annots instanceof PDFArray) {
     annots.push(ref);
   } else {
-     
+
     pdfPage.node.set(PDFName.of('Annots'), pdfPage.doc.context.obj([ref]));
   }
+}
+
+// ── Footer ───────────────────────────────────────────────────
+
+export interface FooterConfig {
+  left:     string;
+  center:   string;
+  right:    string;
+  fontSize: number;
+}
+
+/**
+ * Draw a 3-column footer on every page and return the modified bytes.
+ * Tokens {page} and {total} are replaced with the current page number and total.
+ */
+export async function embedFooter(pdfBytes: Uint8Array, config: FooterConfig): Promise<Uint8Array> {
+  const pdfDoc = await PDFDocument.load(pdfBytes, { ignoreEncryption: true });
+  const font   = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const total  = pdfDoc.getPageCount();
+  const black  = rgb(0, 0, 0);
+  const margin = 40;
+  const yPos   = 20;
+
+  for (let i = 0; i < total; i++) {
+    const page        = pdfDoc.getPage(i);
+    const { width: pdfW } = page.getSize();
+    const resolve     = (t: string) =>
+      t.replace(/\{page\}/g, String(i + 1)).replace(/\{total\}/g, String(total));
+
+    const l = resolve(config.left);
+    const c = resolve(config.center);
+    const r = resolve(config.right);
+
+    if (l) {
+      page.drawText(l, { x: margin, y: yPos, size: config.fontSize, font, color: black });
+    }
+    if (c) {
+      const tw = font.widthOfTextAtSize(c, config.fontSize);
+      page.drawText(c, { x: (pdfW - tw) / 2, y: yPos, size: config.fontSize, font, color: black });
+    }
+    if (r) {
+      const tw = font.widthOfTextAtSize(r, config.fontSize);
+      page.drawText(r, { x: pdfW - margin - tw, y: yPos, size: config.fontSize, font, color: black });
+    }
+  }
+
+  return pdfDoc.save();
+}
+
+// ── Watermark ────────────────────────────────────────────────
+
+export interface WatermarkConfig {
+  text:     string;
+  fontSize: number;
+  opacity:  number;  // 0.0–1.0
+  angle:    number;  // degrees
+}
+
+/**
+ * Draw a centred, rotated text watermark on every page and return the modified bytes.
+ */
+export async function embedWatermark(pdfBytes: Uint8Array, config: WatermarkConfig): Promise<Uint8Array> {
+  const pdfDoc   = await PDFDocument.load(pdfBytes, { ignoreEncryption: true });
+  const font     = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const grey     = rgb(0.5, 0.5, 0.5);
+  const angleRad = (config.angle * Math.PI) / 180;
+
+  for (let i = 0; i < pdfDoc.getPageCount(); i++) {
+    const page              = pdfDoc.getPage(i);
+    const { width: pdfW, height: pdfH } = page.getSize();
+    const textWidth         = font.widthOfTextAtSize(config.text, config.fontSize);
+
+    // Translate origin so the centre of the text string lands at the page centre
+    const x = pdfW / 2
+      - (textWidth / 2)       * Math.cos(angleRad)
+      + (config.fontSize / 2) * Math.sin(angleRad);
+    const y = pdfH / 2
+      - (textWidth / 2)       * Math.sin(angleRad)
+      - (config.fontSize / 2) * Math.cos(angleRad);
+
+    page.drawText(config.text, {
+      x,
+      y,
+      size:    config.fontSize,
+      font,
+      color:   grey,
+      opacity: config.opacity,
+      rotate:  degrees(config.angle),
+    });
+  }
+
+  return pdfDoc.save();
 }

--- a/src/renderer/saver.ts
+++ b/src/renderer/saver.ts
@@ -339,8 +339,9 @@ export async function embedWatermark(pdfBytes: Uint8Array, config: WatermarkConf
 
     lines.forEach((line, li) => {
       const textWidth  = font.widthOfTextAtSize(line, config.fontSize);
-      // Perpendicular offset (CCW 90° from text direction) to space lines
-      const perpOffset = (li - (lines.length - 1) / 2) * lineHeight;
+      // Perpendicular offset (CCW 90° from text direction) to space lines.
+      // Positive perpOffset moves toward the visual top of the page; line 0 is topmost.
+      const perpOffset = ((lines.length - 1) / 2 - li) * lineHeight;
 
       // Centre each line at page centre then offset perpendicularly
       const x = pdfW / 2

--- a/src/renderer/saver.ts
+++ b/src/renderer/saver.ts
@@ -326,32 +326,41 @@ export interface WatermarkConfig {
  * Draw a centred, rotated text watermark on every page and return the modified bytes.
  */
 export async function embedWatermark(pdfBytes: Uint8Array, config: WatermarkConfig): Promise<Uint8Array> {
-  const pdfDoc   = await PDFDocument.load(pdfBytes, { ignoreEncryption: true });
-  const font     = await pdfDoc.embedFont(StandardFonts.Helvetica);
-  const grey     = rgb(0.5, 0.5, 0.5);
-  const angleRad = (config.angle * Math.PI) / 180;
+  const pdfDoc     = await PDFDocument.load(pdfBytes, { ignoreEncryption: true });
+  const font       = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const grey       = rgb(0.5, 0.5, 0.5);
+  const angleRad   = (config.angle * Math.PI) / 180;
+  const lines      = config.text.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+  const lineHeight = config.fontSize * 1.3;
 
   for (let i = 0; i < pdfDoc.getPageCount(); i++) {
-    const page              = pdfDoc.getPage(i);
+    const page = pdfDoc.getPage(i);
     const { width: pdfW, height: pdfH } = page.getSize();
-    const textWidth         = font.widthOfTextAtSize(config.text, config.fontSize);
 
-    // Translate origin so the centre of the text string lands at the page centre
-    const x = pdfW / 2
-      - (textWidth / 2)       * Math.cos(angleRad)
-      + (config.fontSize / 2) * Math.sin(angleRad);
-    const y = pdfH / 2
-      - (textWidth / 2)       * Math.sin(angleRad)
-      - (config.fontSize / 2) * Math.cos(angleRad);
+    lines.forEach((line, li) => {
+      const textWidth  = font.widthOfTextAtSize(line, config.fontSize);
+      // Perpendicular offset (CCW 90° from text direction) to space lines
+      const perpOffset = (li - (lines.length - 1) / 2) * lineHeight;
 
-    page.drawText(config.text, {
-      x,
-      y,
-      size:    config.fontSize,
-      font,
-      color:   grey,
-      opacity: config.opacity,
-      rotate:  degrees(config.angle),
+      // Centre each line at page centre then offset perpendicularly
+      const x = pdfW / 2
+        - (textWidth / 2)        * Math.cos(angleRad)
+        + (config.fontSize / 2)  * Math.sin(angleRad)
+        - perpOffset             * Math.sin(angleRad);
+      const y = pdfH / 2
+        - (textWidth / 2)        * Math.sin(angleRad)
+        - (config.fontSize / 2)  * Math.cos(angleRad)
+        + perpOffset             * Math.cos(angleRad);
+
+      page.drawText(line, {
+        x,
+        y,
+        size:    config.fontSize,
+        font,
+        color:   grey,
+        opacity: config.opacity,
+        rotate:  degrees(config.angle),
+      });
     });
   }
 

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -89,6 +89,7 @@ export interface Tab {
   _notBeenViewed?: boolean;
   _undoStack?: Array<{ pdfBytes: Uint8Array; annotations: string }>;
   _undoIdx?: number;
+  _undoCleanIdx?: number | null;
 }
 
 // ── CloseContext ──────────────────────────────────────────────

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -87,6 +87,8 @@ export interface Tab {
   _savedBytes?: Uint8Array | null;
   _findCache?: Map<number, FindCacheEntry>;
   _notBeenViewed?: boolean;
+  _undoStack?: Array<{ pdfBytes: Uint8Array; annotations: string }>;
+  _undoIdx?: number;
 }
 
 // ── CloseContext ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Remove Pages**: adds a × button to each thumbnail in the Reorder Pages modal; attempting to remove all pages shows an error dialog instead of creating an empty PDF
- **Add Footer**: new sidebar tool that draws a 3-column (left/center/right) footer on every page with free-text inputs and `{page}` / `{total}` token support; embedded permanently into the PDF via pdf-lib on apply
- **Add Watermark**: new sidebar tool that draws a centred, rotated text watermark with configurable font size, opacity (5–100%), and angle; embedded permanently via pdf-lib on apply

All three features follow the same apply-immediately pattern as Reorder Pages — `tab.pdfBytes` is replaced, annotations are cleared, and the viewer reloads.

## Test plan

- [x] Open a multi-page PDF, open Reorder Pages — each thumbnail shows left arrow, right arrow, and × button
- [x] Click × to remove a page — remaining thumbnails renumber correctly; Apply produces a PDF with that page removed
- [x] Click × on every page then Apply — error dialog appears, PDF unchanged
- [x] Open Add Footer, enter `{page} / {total}` in Left column, apply, save, open in external viewer — footer visible bottom-left on each page
- [x] Verify center and right columns align correctly using `widthOfTextAtSize` centering
- [x] Leave all footer fields empty and click Apply — no-op (no reload)
- [x] Open Add Watermark, enter "DRAFT", leave defaults (30% opacity, 45°), apply, save, open externally — diagonal semi-transparent watermark centred on each page
- [ ] Set opacity to 100% and angle to 0° — horizontal fully-opaque watermark
- [x] Leave watermark text empty and click Apply — no-op