### PR TITLE
v0.2.4

### DIFF
--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -1,0 +1,35 @@
+/* Reamlet — Print Preview window styles */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+/* screen layout */
+body { margin: 0; background: #1e1e1e; color: #ccc; font: 13px/1.4 system-ui, sans-serif; display: flex; height: 100vh; overflow: hidden; }
+#settings-panel { width: 200px; min-width: 200px; background: #252526; border-right: 1px solid #333; padding: 16px; display: flex; flex-direction: column; gap: 12px; overflow-y: auto; }
+#preview-area { flex: 1; overflow-y: auto; padding: 24px; display: flex; flex-direction: column; align-items: center; gap: 16px; background: #3c3c3c; }
+.print-page { background: white; box-shadow: 0 2px 8px rgba(0,0,0,0.5); }
+.print-page img { display: block; max-width: 100%; }
+.print-page.excluded { display: none !important; }
+
+/* controls */
+label { display: block; font-size: 12px; color: #999; margin-bottom: 4px; }
+input[type="number"], input[type="text"], select { width: 100%; box-sizing: border-box; background: #3c3c3c; color: #ccc; border: 1px solid #555; border-radius: 3px; padding: 4px 6px; font-size: 12px; }
+.radio-group { display: flex; flex-direction: column; gap: 4px; }
+.radio-group label { display: flex; align-items: center; gap: 6px; color: #ccc; font-size: 12px; margin: 0; }
+button { width: 100%; padding: 7px; border-radius: 4px; border: none; cursor: pointer; font-size: 13px; }
+#btn-print { background: #0078d4; color: white; margin-top: auto; }
+#btn-print:hover { background: #106ebe; }
+#btn-close { background: #3c3c3c; color: #ccc; border: 1px solid #555; margin-top: 6px; }
+#btn-close:hover { background: #4c4c4c; }
+#status { font-size: 11px; color: #888; margin-top: 8px; }
+.hidden { display: none !important; }
+.greyscale .print-page img { filter: grayscale(1); }
+
+/* print output */
+@media print {
+  @page { margin: 0; size: auto; }
+  #settings-panel { display: none !important; }
+  #preview-area { padding: 0; gap: 0; background: white; }
+  body { display: block; }
+  .print-page { box-shadow: none; page-break-after: always; break-after: page; }
+  .print-page.fit img { width: 100vw; height: 100vh; object-fit: contain; display: block; }
+  .print-page:not(.fit) img { display: block; }
+}

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -23,6 +23,37 @@ body {
   overflow-y: auto;
 }
 #settings-panel h3 { margin: 0 0 12px; font-size: 14px; color: #eee; }
+#preview-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #3c3c3c;
+}
+#preview-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  background: #2d2d2d;
+  border-bottom: 1px solid #222;
+  flex-shrink: 0;
+}
+#preview-toolbar button {
+  background: #3c3c3c;
+  color: #ccc;
+  border: 1px solid #555;
+  border-radius: 3px;
+  width: 24px;
+  height: 22px;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+#preview-toolbar button:hover:not(:disabled) { background: #4c4c4c; }
+#preview-toolbar button:disabled { opacity: 0.4; cursor: not-allowed; }
+#zoom-label { font-size: 12px; color: #999; min-width: 38px; text-align: center; }
 #preview-area {
   flex: 1;
   overflow-y: auto;
@@ -31,7 +62,6 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  background: #3c3c3c;
 }
 
 /* ── Settings sections ────────────────────────────────────────── */
@@ -92,12 +122,18 @@ details[open] summary { margin-bottom: 8px; }
 .greyscale .print-page img { filter: grayscale(1); }
 
 /* ── Print output ─────────────────────────────────────────────── */
+@page { margin: 0; size: portrait; }
+@page landscape-page { margin: 0; size: landscape; }
+
 @media print {
-  @page { margin: 0; size: auto; }
+  @page { margin: 0; size: portrait; }
   #settings-panel { display: none !important; }
+  #preview-toolbar { display: none !important; }
   body { display: block; overflow: visible; }
+  #preview-wrapper { display: block; overflow: visible; }
   #preview-area { padding: 0; gap: 0; background: white; overflow: visible; display: block; }
   /* Each page wrapper fills exactly one sheet of paper */
+  .print-page.landscape { page: landscape-page; }
   .print-page {
     box-shadow: none;
     page-break-after: always;

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -122,18 +122,14 @@ details[open] summary { margin-bottom: 8px; }
 .greyscale .print-page img { filter: grayscale(1); }
 
 /* ── Print output ─────────────────────────────────────────────── */
-@page { margin: 0; size: portrait; }
-@page landscape-page { margin: 0; size: landscape; }
-
 @media print {
-  @page { margin: 0; size: portrait; }
+  @page { margin: 0; size: auto; }
   #settings-panel { display: none !important; }
   #preview-toolbar { display: none !important; }
   body { display: block; overflow: visible; }
   #preview-wrapper { display: block; overflow: visible; }
   #preview-area { padding: 0; gap: 0; background: white; overflow: visible; display: block; }
   /* Each page wrapper fills exactly one sheet of paper */
-  .print-page.landscape { page: landscape-page; }
   .print-page {
     box-shadow: none;
     page-break-after: always;

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -117,8 +117,16 @@ details[open] summary { margin-bottom: 8px; }
 #status { font-size: 11px; color: #888; margin-top: 8px; text-align: center; }
 
 /* ── Preview pages ────────────────────────────────────────────── */
-.print-page { background: white; box-shadow: 0 2px 8px rgba(0,0,0,0.5); }
-.print-page img { display: block; }
+.print-page {
+  background: white;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.print-page img { display: block; max-width: 100%; max-height: 100%; }
 .greyscale .print-page img { filter: grayscale(1); }
 
 /* ── Print output ─────────────────────────────────────────────── */

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -96,7 +96,27 @@ details[open] summary { margin-bottom: 8px; }
   @page { margin: 0; size: auto; }
   #settings-panel { display: none !important; }
   body { display: block; overflow: visible; }
-  #preview-area { padding: 0; gap: 0; background: white; overflow: visible; }
-  .print-page { box-shadow: none; page-break-after: always; break-after: page; }
-  .print-page img { width: 100vw; height: 100vh; object-fit: contain; display: block; }
+  #preview-area { padding: 0; gap: 0; background: white; overflow: visible; display: block; }
+  /* Each page wrapper fills exactly one sheet of paper */
+  .print-page {
+    box-shadow: none;
+    page-break-after: always;
+    break-after: page;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: white;
+  }
+  /* Override inline px dimensions so the image scales to fit the paper.
+     !important is required to beat the inline style attribute. */
+  .print-page img {
+    width: auto !important;
+    height: auto !important;
+    max-width: 100% !important;
+    max-height: 100% !important;
+    display: block;
+  }
 }

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -118,7 +118,7 @@ details[open] summary { margin-bottom: 8px; }
 
 /* ── Preview pages ────────────────────────────────────────────── */
 .print-page { background: white; box-shadow: 0 2px 8px rgba(0,0,0,0.5); }
-.print-page img { display: block; max-width: 100%; }
+.print-page img { display: block; }
 .greyscale .print-page img { filter: grayscale(1); }
 
 /* ── Print output ─────────────────────────────────────────────── */
@@ -128,7 +128,7 @@ details[open] summary { margin-bottom: 8px; }
   #preview-toolbar { display: none !important; }
   body { display: block; overflow: visible; }
   #preview-wrapper { display: block; overflow: visible; }
-  #preview-area { padding: 0; gap: 0; background: white; overflow: visible; display: block; }
+  #preview-area { padding: 0; gap: 0; background: white; overflow: visible; display: block; zoom: normal; }
   /* Each page wrapper fills exactly one sheet of paper */
   .print-page {
     box-shadow: none;

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -1,35 +1,102 @@
 /* Reamlet — Print Preview window styles */
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
-/* screen layout */
-body { margin: 0; background: #1e1e1e; color: #ccc; font: 13px/1.4 system-ui, sans-serif; display: flex; height: 100vh; overflow: hidden; }
-#settings-panel { width: 200px; min-width: 200px; background: #252526; border-right: 1px solid #333; padding: 16px; display: flex; flex-direction: column; gap: 12px; overflow-y: auto; }
-#preview-area { flex: 1; overflow-y: auto; padding: 24px; display: flex; flex-direction: column; align-items: center; gap: 16px; background: #3c3c3c; }
+/* ── Layout ───────────────────────────────────────────────────── */
+body {
+  margin: 0;
+  background: #1e1e1e;
+  color: #ccc;
+  font: 13px/1.4 system-ui, sans-serif;
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+}
+#settings-panel {
+  width: 210px;
+  min-width: 210px;
+  background: #252526;
+  border-right: 1px solid #333;
+  padding: 14px 14px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  overflow-y: auto;
+}
+#settings-panel h3 { margin: 0 0 12px; font-size: 14px; color: #eee; }
+#preview-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  background: #3c3c3c;
+}
+
+/* ── Settings sections ────────────────────────────────────────── */
+section { margin-bottom: 12px; }
+section.row { display: flex; align-items: flex-end; gap: 10px; }
+section.row > div { flex: 1; }
+label { display: block; font-size: 11px; color: #999; margin-bottom: 3px; }
+.checkbox-label { display: flex !important; align-items: center; gap: 6px; color: #ccc !important; font-size: 12px !important; margin: 0 !important; cursor: pointer; }
+.radio-group { display: flex; flex-direction: column; gap: 4px; }
+.radio-group label { display: flex; align-items: center; gap: 6px; color: #ccc; font-size: 12px; margin: 0; cursor: pointer; }
+input[type="number"],
+input[type="text"],
+select {
+  width: 100%;
+  box-sizing: border-box;
+  background: #3c3c3c;
+  color: #ccc;
+  border: 1px solid #555;
+  border-radius: 3px;
+  padding: 4px 6px;
+  font-size: 12px;
+}
+select { cursor: pointer; }
+
+/* More settings */
+details { margin-bottom: 12px; }
+summary { font-size: 12px; color: #888; cursor: pointer; user-select: none; padding: 4px 0; }
+summary:hover { color: #ccc; }
+details[open] summary { margin-bottom: 8px; }
+.hint { font-size: 11px; color: #666; margin: 4px 0 0; }
+
+/* Printer Preferences button */
+#btn-printer-pref {
+  width: 100%;
+  margin-top: 5px;
+  padding: 5px;
+  background: #3c3c3c;
+  color: #ccc;
+  border: 1px solid #555;
+  border-radius: 3px;
+  font-size: 11px;
+  cursor: pointer;
+}
+#btn-printer-pref:hover { background: #4c4c4c; }
+
+/* Actions */
+.actions { margin-top: auto; padding-top: 10px; display: flex; flex-direction: column; gap: 6px; }
+#btn-print { background: #0078d4; color: white; padding: 7px; border-radius: 4px; border: none; cursor: pointer; font-size: 13px; width: 100%; }
+#btn-print:hover { background: #106ebe; }
+#btn-print:disabled { background: #555; cursor: not-allowed; }
+#btn-close { background: #3c3c3c; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 7px; cursor: pointer; font-size: 13px; width: 100%; }
+#btn-close:hover { background: #4c4c4c; }
+#status { font-size: 11px; color: #888; margin-top: 8px; text-align: center; }
+
+/* ── Preview pages ────────────────────────────────────────────── */
 .print-page { background: white; box-shadow: 0 2px 8px rgba(0,0,0,0.5); }
 .print-page img { display: block; max-width: 100%; }
-.print-page.excluded { display: none !important; }
-
-/* controls */
-label { display: block; font-size: 12px; color: #999; margin-bottom: 4px; }
-input[type="number"], input[type="text"], select { width: 100%; box-sizing: border-box; background: #3c3c3c; color: #ccc; border: 1px solid #555; border-radius: 3px; padding: 4px 6px; font-size: 12px; }
-.radio-group { display: flex; flex-direction: column; gap: 4px; }
-.radio-group label { display: flex; align-items: center; gap: 6px; color: #ccc; font-size: 12px; margin: 0; }
-button { width: 100%; padding: 7px; border-radius: 4px; border: none; cursor: pointer; font-size: 13px; }
-#btn-print { background: #0078d4; color: white; margin-top: auto; }
-#btn-print:hover { background: #106ebe; }
-#btn-close { background: #3c3c3c; color: #ccc; border: 1px solid #555; margin-top: 6px; }
-#btn-close:hover { background: #4c4c4c; }
-#status { font-size: 11px; color: #888; margin-top: 8px; }
-.hidden { display: none !important; }
 .greyscale .print-page img { filter: grayscale(1); }
 
-/* print output */
+/* ── Print output ─────────────────────────────────────────────── */
 @media print {
   @page { margin: 0; size: auto; }
   #settings-panel { display: none !important; }
-  #preview-area { padding: 0; gap: 0; background: white; }
-  body { display: block; }
+  body { display: block; overflow: visible; }
+  #preview-area { padding: 0; gap: 0; background: white; overflow: visible; }
   .print-page { box-shadow: none; page-break-after: always; break-after: page; }
-  .print-page.fit img { width: 100vw; height: 100vh; object-fit: contain; display: block; }
-  .print-page:not(.fit) img { display: block; }
+  .print-page img { width: 100vw; height: 100vh; object-fit: contain; display: block; }
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -887,7 +887,7 @@ html, body {
   font-size: 12px;
 }
 .footer-col select { cursor: pointer; }
-.footer-custom-hidden { display: none; }
+.footer-custom-hidden { visibility: hidden; }
 .footer-size-row {
   display: flex;
   align-items: center;

--- a/assets/style.css
+++ b/assets/style.css
@@ -938,7 +938,8 @@ html, body {
 }
 
 /* ── Context menu ─────────────────────────────────────────────── */
-#context-menu {
+#context-menu,
+#input-ctx-menu {
   position: fixed;
   z-index: 1000;
   background: var(--bar-bg);
@@ -948,9 +949,11 @@ html, body {
   padding: 4px;
   min-width: 140px;
 }
-#context-menu.hidden { display: none; }
+#context-menu.hidden,
+#input-ctx-menu.hidden { display: none; }
 
-#context-menu button {
+#context-menu button,
+#input-ctx-menu button {
   display: block;
   width: 100%;
   background: transparent;
@@ -962,9 +965,12 @@ html, body {
   border-radius: 3px;
   text-align: left;
 }
-#context-menu button:hover { background: var(--accent); color: #fff; }
-#context-menu button:disabled { opacity: 0.4; cursor: default; }
-#context-menu button:disabled:hover { background: transparent; color: var(--text); }
+#context-menu button:hover,
+#input-ctx-menu button:hover { background: var(--accent); color: #fff; }
+#context-menu button:disabled,
+#input-ctx-menu button:disabled { opacity: 0.4; cursor: default; }
+#context-menu button:disabled:hover,
+#input-ctx-menu button:disabled:hover { background: transparent; color: var(--text); }
 
 /* ── Tab context menu ──────────────────────────────────────────── */
 #tab-context-menu {

--- a/assets/style.css
+++ b/assets/style.css
@@ -937,6 +937,7 @@ html, body {
   .form-layer   { display: none !important; }
   body { background: white; overflow: visible; }
   html { overflow: visible; }
+  #print-debug-overlay { display: block !important; position: static !important; }
 }
 
 /* ── Context menu ─────────────────────────────────────────────── */

--- a/assets/style.css
+++ b/assets/style.css
@@ -927,14 +927,17 @@ html, body {
 }
 .wm-row label { width: 72px; color: #999; flex-shrink: 0; }
 .wm-row input[type="text"],
-.wm-row input[type="number"] {
+.wm-row input[type="number"],
+.wm-row textarea {
   padding: 5px 7px;
   background: #2a2a2a;
   border: 1px solid var(--border);
   border-radius: 3px;
   color: var(--text);
   font-size: 12px;
+  font-family: inherit;
 }
+.wm-row textarea { min-height: 52px; }
 .wm-row span { color: #999; }
 #watermark-opacity-val { min-width: 32px; text-align: right; color: var(--text); }
 #watermark-preview {

--- a/assets/style.css
+++ b/assets/style.css
@@ -925,12 +925,14 @@ html, body {
 
 /* ── Print ────────────────────────────────────────────────────── */
 @media print {
+  @page { margin: 0; }
   #topbar, #sidebar, #toc-panel, #empty-state, #viewer-scrollbar, #viewer-scrollbar-h { display: none !important; }
   #content-area { position: static; overflow: visible; }
   #viewer-host  { position: static; overflow: visible; }
   .viewer-pane  { display: none; position: static; overflow: visible; }
   .viewer-pane.active { display: block; }
-  .page-wrapper { page-break-after: always; break-after: page; box-shadow: none; }
+  .page-wrapper { page-break-after: always; break-after: page; box-shadow: none; width: 100vw !important; height: 100vh !important; overflow: hidden; }
+  .page-wrapper canvas { width: 100% !important; height: 100% !important; }
   .annot-canvas { display: block; }
   .form-layer   { display: none !important; }
   body { background: white; overflow: visible; }

--- a/assets/style.css
+++ b/assets/style.css
@@ -865,6 +865,62 @@ html, body {
   line-height: 1;
 }
 .reorder-arrow:hover { background: var(--border); }
+.reorder-remove { color: #c55; }
+.reorder-remove:hover { color: #e33; background: var(--border); }
+
+/* ── Footer modal ────────────────────────────────────────────── */
+#footer-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.footer-col { display: flex; flex-direction: column; gap: 4px; }
+.footer-col label { font-size: 11px; color: #999; }
+.footer-col input {
+  padding: 5px 7px;
+  background: #2a2a2a;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text);
+  font-size: 12px;
+}
+.footer-size-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #999;
+}
+.footer-size-row input {
+  padding: 4px 6px;
+  background: #2a2a2a;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text);
+  font-size: 12px;
+}
+
+/* ── Watermark modal ─────────────────────────────────────────── */
+.wm-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 12px;
+}
+.wm-row label { width: 72px; color: #999; flex-shrink: 0; }
+.wm-row input[type="text"],
+.wm-row input[type="number"] {
+  padding: 5px 7px;
+  background: #2a2a2a;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text);
+  font-size: 12px;
+}
+.wm-row span { color: #999; }
+#watermark-opacity-val { min-width: 32px; text-align: right; color: var(--text); }
 
 /* ── Loading spinner ─────────────────────────────────────────── */
 .loading-overlay {

--- a/assets/style.css
+++ b/assets/style.css
@@ -877,7 +877,8 @@ html, body {
 }
 .footer-col { display: flex; flex-direction: column; gap: 4px; }
 .footer-col label { font-size: 11px; color: #999; }
-.footer-col input {
+.footer-col select,
+.footer-col input[type="text"] {
   padding: 5px 7px;
   background: #2a2a2a;
   border: 1px solid var(--border);
@@ -885,12 +886,15 @@ html, body {
   color: var(--text);
   font-size: 12px;
 }
+.footer-col select { cursor: pointer; }
+.footer-custom-hidden { display: none; }
 .footer-size-row {
   display: flex;
   align-items: center;
   gap: 6px;
   font-size: 12px;
   color: #999;
+  margin-bottom: 10px;
 }
 .footer-size-row input {
   padding: 4px 6px;
@@ -900,8 +904,20 @@ html, body {
   color: var(--text);
   font-size: 12px;
 }
+#footer-preview {
+  display: block;
+  width: 100%;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+}
 
 /* ── Watermark modal ─────────────────────────────────────────── */
+#watermark-modal-body {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+.wm-fields { flex: 1; min-width: 0; }
 .wm-row {
   display: flex;
   align-items: center;
@@ -921,6 +937,11 @@ html, body {
 }
 .wm-row span { color: #999; }
 #watermark-opacity-val { min-width: 32px; text-align: right; color: var(--text); }
+#watermark-preview {
+  flex-shrink: 0;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+}
 
 /* ── Loading spinner ─────────────────────────────────────────── */
 .loading-overlay {

--- a/assets/style.css
+++ b/assets/style.css
@@ -925,19 +925,16 @@ html, body {
 
 /* ── Print ────────────────────────────────────────────────────── */
 @media print {
-  @page { margin: 0; }
   #topbar, #sidebar, #toc-panel, #empty-state, #viewer-scrollbar, #viewer-scrollbar-h { display: none !important; }
   #content-area { position: static; overflow: visible; }
   #viewer-host  { position: static; overflow: visible; }
   .viewer-pane  { display: none; position: static; overflow: visible; }
   .viewer-pane.active { display: block; }
-  .page-wrapper { page-break-after: always; break-after: page; box-shadow: none; width: 100vw !important; height: 100vh !important; overflow: hidden; }
-  .page-wrapper canvas { width: 100% !important; height: 100% !important; }
+  .page-wrapper { page-break-after: always; break-after: page; box-shadow: none; }
   .annot-canvas { display: block; }
   .form-layer   { display: none !important; }
   body { background: white; overflow: visible; }
   html { overflow: visible; }
-  #print-debug-overlay { display: block !important; position: static !important; }
 }
 
 /* ── Context menu ─────────────────────────────────────────────── */

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -25,6 +25,8 @@
             <button data-menu="save">Save <span>Ctrl+S</span></button>
             <button data-menu="save-copy">Save Copy… <span>Ctrl+⇧+S</span></button>
             <div class="tdrop-sep"></div>
+            <button data-menu="print">Print… <span>Ctrl+P</span></button>
+            <div class="tdrop-sep"></div>
             <button data-menu="close-tab">Close Tab <span>Ctrl+W</span></button>
             <button data-menu="reopen-tab">Reopen Tab <span>Ctrl+⇧+T</span></button>
             <div class="tdrop-sep"></div>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -378,6 +378,13 @@
     <button data-ctx="find">Find</button>
   </div>
 
+  <!-- ── Input context menu ───────────────────────────────────── -->
+  <div id="input-ctx-menu" class="hidden">
+    <button data-input-ctx="cut">Cut</button>
+    <button data-input-ctx="copy">Copy</button>
+    <button data-input-ctx="paste">Paste</button>
+  </div>
+
   <!-- ── Tab context menu ──────────────────────────────────────── -->
   <div id="tab-context-menu" class="hidden">
     <button data-tctx="close">Close</button>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -421,7 +421,7 @@
         <div class="wm-fields">
           <div class="wm-row">
             <label for="watermark-text">Text</label>
-            <input id="watermark-text" type="text" placeholder="e.g. DRAFT" style="flex:1;" />
+            <textarea id="watermark-text" rows="3" placeholder="e.g. DRAFT&#10;CONFIDENTIAL" style="flex:1;resize:vertical;"></textarea>
           </div>
           <div class="wm-row">
             <label for="watermark-fontsize">Font size</label>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -259,6 +259,23 @@
           </svg>
           Reorder Pages
         </button>
+        <button id="btn-footer" class="tool-panel-btn">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="3" y1="20" x2="21" y2="20"/>
+            <line x1="3" y1="15" x2="8"  y2="15"/>
+            <line x1="10" y1="15" x2="14" y2="15"/>
+            <line x1="16" y1="15" x2="21" y2="15"/>
+          </svg>
+          Add Footer
+        </button>
+        <button id="btn-watermark" class="tool-panel-btn">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+            <path d="M2 17l10 5 10-5"/>
+            <path d="M2 12l10 5 10-5"/>
+          </svg>
+          Add Watermark
+        </button>
       </div>
 
       <!-- Drag handle on right edge -->
@@ -329,13 +346,79 @@
   <div id="reorder-modal" class="modal-overlay hidden">
     <div class="modal-box" style="min-width:560px;">
       <div class="modal-title">Reorder Pages</div>
-      <p class="modal-hint">Drag page thumbnails to reorder them.</p>
+      <p class="modal-hint">Drag thumbnails to reorder, or use the arrows. Click &times; to remove a page.</p>
       <div class="modal-body">
         <div id="reorder-pages"></div>
       </div>
       <div class="modal-footer">
         <button class="modal-btn" id="reorder-cancel">Cancel</button>
         <button class="modal-btn primary" id="reorder-ok">Apply</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Footer modal ─────────────────────────────────────────── -->
+  <div id="footer-modal" class="modal-overlay hidden">
+    <div class="modal-box" style="min-width:480px;">
+      <div class="modal-title">Add Footer</div>
+      <p class="modal-hint">Appears on every page. Use {page} and {total} for page numbers.</p>
+      <div class="modal-body">
+        <div id="footer-cols">
+          <div class="footer-col">
+            <label for="footer-left">Left</label>
+            <input id="footer-left" type="text" placeholder="e.g. {page} / {total}" />
+          </div>
+          <div class="footer-col">
+            <label for="footer-center">Center</label>
+            <input id="footer-center" type="text" placeholder="Centered text" />
+          </div>
+          <div class="footer-col">
+            <label for="footer-right">Right</label>
+            <input id="footer-right" type="text" placeholder="Right-aligned text" />
+          </div>
+        </div>
+        <div class="footer-size-row">
+          <label for="footer-fontsize">Font size</label>
+          <input id="footer-fontsize" type="number" value="10" min="4" max="72" style="width:60px;" />
+          <span>pt</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="modal-btn" id="footer-cancel">Cancel</button>
+        <button class="modal-btn primary" id="footer-ok">Apply</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Watermark modal ───────────────────────────────────────── -->
+  <div id="watermark-modal" class="modal-overlay hidden">
+    <div class="modal-box" style="min-width:360px;">
+      <div class="modal-title">Add Watermark</div>
+      <p class="modal-hint">Embedded permanently into the PDF.</p>
+      <div class="modal-body">
+        <div class="wm-row">
+          <label for="watermark-text">Text</label>
+          <input id="watermark-text" type="text" placeholder="e.g. DRAFT" style="flex:1;" />
+        </div>
+        <div class="wm-row">
+          <label for="watermark-fontsize">Font size</label>
+          <input id="watermark-fontsize" type="number" value="72" min="8" max="400" style="width:70px;" />
+          <span>pt</span>
+        </div>
+        <div class="wm-row">
+          <label for="watermark-opacity">Opacity</label>
+          <input id="watermark-opacity" type="range" min="5" max="100" value="30" style="flex:1;" />
+          <span id="watermark-opacity-val">30%</span>
+        </div>
+        <div class="wm-row">
+          <label for="watermark-angle">Angle</label>
+          <input id="watermark-angle" type="number" value="45" min="0" max="360" style="width:70px;" />
+          <span>&#176;</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="modal-btn" id="watermark-cancel">Cancel</button>
+        <button class="modal-btn primary" id="watermark-ok">Apply</button>
       </div>
     </div>
   </div>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -361,20 +361,41 @@
   <div id="footer-modal" class="modal-overlay hidden">
     <div class="modal-box" style="min-width:480px;">
       <div class="modal-title">Add Footer</div>
-      <p class="modal-hint">Appears on every page. Use {page} and {total} for page numbers.</p>
+      <p class="modal-hint">Embedded permanently on every page.</p>
       <div class="modal-body">
         <div id="footer-cols">
           <div class="footer-col">
-            <label for="footer-left">Left</label>
-            <input id="footer-left" type="text" placeholder="e.g. {page} / {total}" />
+            <label for="footer-left-sel">Left</label>
+            <select id="footer-left-sel">
+              <option value="">None</option>
+              <option value="date">Date</option>
+              <option value="page">Page number</option>
+              <option value="page-total">Page / Total</option>
+              <option value="custom">Custom&hellip;</option>
+            </select>
+            <input id="footer-left-custom" class="footer-custom footer-custom-hidden" type="text" placeholder="Custom text" />
           </div>
           <div class="footer-col">
-            <label for="footer-center">Center</label>
-            <input id="footer-center" type="text" placeholder="Centered text" />
+            <label for="footer-center-sel">Center</label>
+            <select id="footer-center-sel">
+              <option value="">None</option>
+              <option value="date">Date</option>
+              <option value="page" selected>Page number</option>
+              <option value="page-total">Page / Total</option>
+              <option value="custom">Custom&hellip;</option>
+            </select>
+            <input id="footer-center-custom" class="footer-custom footer-custom-hidden" type="text" placeholder="Custom text" />
           </div>
           <div class="footer-col">
-            <label for="footer-right">Right</label>
-            <input id="footer-right" type="text" placeholder="Right-aligned text" />
+            <label for="footer-right-sel">Right</label>
+            <select id="footer-right-sel">
+              <option value="">None</option>
+              <option value="date">Date</option>
+              <option value="page">Page number</option>
+              <option value="page-total">Page / Total</option>
+              <option value="custom">Custom&hellip;</option>
+            </select>
+            <input id="footer-right-custom" class="footer-custom footer-custom-hidden" type="text" placeholder="Custom text" />
           </div>
         </div>
         <div class="footer-size-row">
@@ -382,6 +403,7 @@
           <input id="footer-fontsize" type="number" value="10" min="4" max="72" style="width:60px;" />
           <span>pt</span>
         </div>
+        <canvas id="footer-preview" width="440" height="140"></canvas>
       </div>
       <div class="modal-footer">
         <button class="modal-btn" id="footer-cancel">Cancel</button>
@@ -392,29 +414,32 @@
 
   <!-- ── Watermark modal ───────────────────────────────────────── -->
   <div id="watermark-modal" class="modal-overlay hidden">
-    <div class="modal-box" style="min-width:360px;">
+    <div class="modal-box" style="min-width:400px;">
       <div class="modal-title">Add Watermark</div>
       <p class="modal-hint">Embedded permanently into the PDF.</p>
-      <div class="modal-body">
-        <div class="wm-row">
-          <label for="watermark-text">Text</label>
-          <input id="watermark-text" type="text" placeholder="e.g. DRAFT" style="flex:1;" />
+      <div class="modal-body" id="watermark-modal-body">
+        <div class="wm-fields">
+          <div class="wm-row">
+            <label for="watermark-text">Text</label>
+            <input id="watermark-text" type="text" placeholder="e.g. DRAFT" style="flex:1;" />
+          </div>
+          <div class="wm-row">
+            <label for="watermark-fontsize">Font size</label>
+            <input id="watermark-fontsize" type="number" value="72" min="8" max="400" style="width:70px;" />
+            <span>pt</span>
+          </div>
+          <div class="wm-row">
+            <label for="watermark-opacity">Opacity</label>
+            <input id="watermark-opacity" type="range" min="5" max="100" value="30" style="flex:1;" />
+            <span id="watermark-opacity-val">30%</span>
+          </div>
+          <div class="wm-row">
+            <label for="watermark-angle">Angle</label>
+            <input id="watermark-angle" type="number" value="45" min="0" max="360" style="width:70px;" />
+            <span>&#176;</span>
+          </div>
         </div>
-        <div class="wm-row">
-          <label for="watermark-fontsize">Font size</label>
-          <input id="watermark-fontsize" type="number" value="72" min="8" max="400" style="width:70px;" />
-          <span>pt</span>
-        </div>
-        <div class="wm-row">
-          <label for="watermark-opacity">Opacity</label>
-          <input id="watermark-opacity" type="range" min="5" max="100" value="30" style="flex:1;" />
-          <span id="watermark-opacity-val">30%</span>
-        </div>
-        <div class="wm-row">
-          <label for="watermark-angle">Angle</label>
-          <input id="watermark-angle" type="number" value="45" min="0" max="360" style="width:70px;" />
-          <span>&#176;</span>
-        </div>
+        <canvas id="watermark-preview" width="120" height="155"></canvas>
       </div>
       <div class="modal-footer">
         <button class="modal-btn" id="watermark-cancel">Cancel</button>

--- a/renderer/print-preview.html
+++ b/renderer/print-preview.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<!-- Reamlet — SPDX-License-Identifier: GPL-3.0-or-later -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self' file:; script-src 'self' 'unsafe-eval' file:; style-src 'self' 'unsafe-inline'; worker-src blob: file:; img-src 'self' data: file:;" />
+  <title>Print</title>
+  <link rel="stylesheet" href="../assets/print-preview.css" />
+</head>
+<body>
+  <div id="settings-panel">
+    <h3 style="margin:0 0 4px;">Print</h3>
+
+    <div>
+      <label for="inp-copies">Copies</label>
+      <input type="number" id="inp-copies" min="1" max="99" value="1" />
+    </div>
+
+    <div>
+      <label for="sel-pages">Pages</label>
+      <select id="sel-pages">
+        <option value="all">All</option>
+        <option value="custom">Custom…</option>
+      </select>
+      <input type="text" id="inp-pages-custom" placeholder="e.g. 1–3, 5" class="hidden" style="margin-top:4px;" />
+    </div>
+
+    <div>
+      <label for="sel-scale">Scale</label>
+      <select id="sel-scale">
+        <option value="fit">Fit to page</option>
+        <option value="100">100%</option>
+        <option value="75">75%</option>
+        <option value="50">50%</option>
+        <option value="25">25%</option>
+      </select>
+    </div>
+
+    <div>
+      <label>Colour</label>
+      <div class="radio-group">
+        <label><input type="radio" name="color" value="color" checked /> Colour</label>
+        <label><input type="radio" name="color" value="grey" /> Greyscale</label>
+      </div>
+    </div>
+
+    <button id="btn-print">Print</button>
+    <button id="btn-close">Close</button>
+    <div id="status">Loading…</div>
+  </div>
+
+  <div id="preview-area"></div>
+
+  <script type="module" src="../out/renderer/print-preview.js"></script>
+</body>
+</html>

--- a/renderer/print-preview.html
+++ b/renderer/print-preview.html
@@ -10,43 +10,85 @@
 </head>
 <body>
   <div id="settings-panel">
-    <h3 style="margin:0 0 4px;">Print</h3>
+    <h3>Print</h3>
 
-    <div>
-      <label for="inp-copies">Copies</label>
-      <input type="number" id="inp-copies" min="1" max="99" value="1" />
-    </div>
+    <section>
+      <label for="sel-printer">Printer</label>
+      <select id="sel-printer"></select>
+      <button id="btn-printer-pref">Printer Preferences</button>
+    </section>
 
-    <div>
-      <label for="sel-pages">Pages</label>
-      <select id="sel-pages">
-        <option value="all">All</option>
-        <option value="custom">Custom…</option>
-      </select>
-      <input type="text" id="inp-pages-custom" placeholder="e.g. 1–3, 5" class="hidden" style="margin-top:4px;" />
-    </div>
+    <section class="row">
+      <div>
+        <label for="inp-copies">Copies</label>
+        <input type="number" id="inp-copies" min="1" max="99" value="1" />
+      </div>
+      <label class="checkbox-label">
+        <input type="checkbox" id="chk-collate" /> Collate
+      </label>
+    </section>
 
-    <div>
+    <section>
+      <label for="inp-pages">Pages</label>
+      <input type="text" id="inp-pages" placeholder="All" />
+    </section>
+
+    <section>
       <label for="sel-scale">Scale</label>
       <select id="sel-scale">
-        <option value="fit">Fit to page</option>
+        <option value="fit" selected>Fit to page</option>
         <option value="100">100%</option>
         <option value="75">75%</option>
         <option value="50">50%</option>
         <option value="25">25%</option>
       </select>
-    </div>
+    </section>
 
-    <div>
+    <section>
       <label>Colour</label>
       <div class="radio-group">
         <label><input type="radio" name="color" value="color" checked /> Colour</label>
         <label><input type="radio" name="color" value="grey" /> Greyscale</label>
       </div>
+    </section>
+
+    <details id="more-settings">
+      <summary>More settings</summary>
+
+      <section>
+        <label for="sel-pps">Pages per sheet</label>
+        <select id="sel-pps">
+          <option value="1" selected>1</option>
+          <option value="2">2</option>
+          <option value="4">4</option>
+          <option value="6">6</option>
+          <option value="9">9</option>
+          <option value="16">16</option>
+        </select>
+      </section>
+
+      <section>
+        <label for="sel-duplex">Two-sided</label>
+        <select id="sel-duplex">
+          <option value="simplex" selected>None</option>
+          <option value="longEdge">Long edge</option>
+          <option value="shortEdge">Short edge</option>
+        </select>
+      </section>
+
+      <section>
+        <label class="checkbox-label">
+          <input type="checkbox" id="chk-booklet" /> Booklet
+        </label>
+        <p class="hint">Arranges pages for folding into a booklet. Uses two pages per sheet.</p>
+      </section>
+    </details>
+
+    <div class="actions">
+      <button id="btn-print">Print</button>
+      <button id="btn-close">Close</button>
     </div>
 
-    <button id="btn-print">Print</button>
-    <button id="btn-close">Close</button>
     <div id="status">Loading…</div>
   </div>
 

--- a/renderer/print-preview.html
+++ b/renderer/print-preview.html
@@ -45,6 +45,14 @@
     </section>
 
     <section>
+      <label>Orientation</label>
+      <div class="radio-group">
+        <label><input type="radio" name="orientation" value="portrait"  checked /> Portrait</label>
+        <label><input type="radio" name="orientation" value="landscape"         /> Landscape</label>
+      </div>
+    </section>
+
+    <section>
       <label>Colour</label>
       <div class="radio-group">
         <label><input type="radio" name="color" value="color" checked /> Colour</label>

--- a/renderer/print-preview.html
+++ b/renderer/print-preview.html
@@ -80,7 +80,7 @@
         <label class="checkbox-label">
           <input type="checkbox" id="chk-booklet" /> Booklet
         </label>
-        <p class="hint">Arranges pages for folding into a booklet. Uses two pages per sheet.</p>
+        <p class="hint">Arranges pages for folding into a booklet. Uses two pages per sheet. Prints all pages regardless of the Pages field.</p>
       </section>
     </details>
 

--- a/renderer/print-preview.html
+++ b/renderer/print-preview.html
@@ -92,7 +92,14 @@
     <div id="status">Loading…</div>
   </div>
 
-  <div id="preview-area"></div>
+  <div id="preview-wrapper">
+    <div id="preview-toolbar">
+      <button id="btn-zoom-out" title="Zoom out">−</button>
+      <span id="zoom-label">100%</span>
+      <button id="btn-zoom-in" title="Zoom in">+</button>
+    </div>
+    <div id="preview-area"></div>
+  </div>
 
   <script type="module" src="../out/renderer/print-preview.js"></script>
 </body>

--- a/src/main.ts
+++ b/src/main.ts
@@ -240,7 +240,10 @@ ipcMain.handle('get-printers', async (event: IpcMainInvokeEvent) => {
 });
 
 // Open the Windows printer preferences dialog for the given printer
-ipcMain.handle('open-printer-preferences', (_event: IpcMainInvokeEvent, printerName: string) => {
+ipcMain.handle('open-printer-preferences', async (event: IpcMainInvokeEvent, printerName: string) => {
+  const printers = await event.sender.getPrintersAsync();
+  const valid = printers.some((p: { name: string }) => p.name === printerName);
+  if (!valid) return { ok: false, error: 'Unknown printer.' };
   const safe = printerName.replace(/["]/g, '');
   exec(`rundll32 printui.dll,PrintUIEntry /e /n "${safe}"`);
   return { ok: true };

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,33 +234,43 @@ ipcMain.handle('reveal-in-explorer', (_event: IpcMainInvokeEvent, filePath: stri
   return { ok: true };
 });
 
-// Open the PDF file in a Chromium window and invoke the system print dialog.
-// This bypasses the canvas renderer entirely so the output is always correct.
-ipcMain.handle('print-pdf', async (_event: IpcMainInvokeEvent, filePath: string): Promise<{ ok: boolean; error?: string }> => {
+// Open a visible print preview window where the user can configure and execute printing.
+ipcMain.handle('open-print-preview', async (_event: IpcMainInvokeEvent, filePath: string): Promise<{ ok: boolean; error?: string }> => {
   if (!filePath || !fs.existsSync(filePath)) return { ok: false, error: 'File not found.' };
 
-  const printWin: BW = new BrowserWindow({
+  const previewWin: BW = new BrowserWindow({
+    width: 960,
+    height: 700,
+    minWidth: 600,
+    minHeight: 400,
+    title: 'Print',
     show: false,
-    skipTaskbar: true,
-    webPreferences: { nodeIntegration: false, contextIsolation: true },
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js'),
+    },
   });
 
-  await printWin.loadURL('file:///' + filePath.replace(/\\/g, '/'));
+  await previewWin.loadFile(path.join(__dirname, '..', 'renderer', 'print-preview.html'));
+  previewWin.show();
 
-  // Chromium skips GPU compositing for windows that are never shown, producing blank
-  // print output. Show the window (without stealing focus) so the PDF viewer renders,
-  // then wait for the PDF title update which signals the viewer has finished loading.
-  printWin.showInactive();
-  await new Promise<void>(resolve => {
-    const tid = setTimeout(resolve, 3000);
-    printWin.webContents.once('page-title-updated', () => { clearTimeout(tid); resolve(); });
-  });
+  const buffer = fs.readFileSync(filePath);
+  previewWin.webContents.send('pdf-data', { buffer: buffer.buffer });
+
+  return { ok: true };
+});
+
+// Execute the print dialog from the preview window's renderer process.
+ipcMain.handle('execute-print', (_event: IpcMainInvokeEvent, options: { copies: number; color: boolean; scaleFactor: number }): Promise<{ ok: boolean; error?: string }> => {
+  const win = BrowserWindow.fromWebContents(_event.sender);
+  if (!win) return Promise.resolve({ ok: false, error: 'No window.' });
 
   return new Promise(resolve => {
-    printWin.webContents.print({ silent: false }, (success: boolean, errorType: string) => {
-      printWin.destroy();
-      resolve(success ? { ok: true } : { ok: false, error: errorType });
-    });
+    win.webContents.print(
+      { silent: false, copies: options.copies, color: options.color, scaleFactor: options.scaleFactor },
+      (success: boolean, errorType: string) => resolve(success ? { ok: true } : { ok: false, error: errorType })
+    );
   });
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,12 +6,11 @@
 import type { BrowserWindow as BW, NativeImage, IpcMainInvokeEvent, IpcMainEvent, Event as ElectronEvent } from 'electron';
 
 const { app, BrowserWindow, ipcMain, dialog, Menu, nativeImage, shell } = require('electron');
-const { exec } = require('child_process');
+const { exec, execFile } = require('child_process');
 const path  = require('path');
 const fs    = require('fs');
 const os    = require('os');
 const https = require('https');
-const http  = require('http');
 
 // ── Window factory ─────────────────────────────────────────────
 
@@ -206,6 +205,7 @@ ipcMain.handle('notify-tab-transferred', (_event: IpcMainInvokeEvent, sourceWind
 });
 
 ipcMain.on('open-devtools', (event: IpcMainEvent) => {
+  if (app.isPackaged) return;
   BrowserWindow.fromWebContents(event.sender)?.webContents.toggleDevTools();
 });
 
@@ -213,9 +213,8 @@ ipcMain.on('open-devtools', (event: IpcMainEvent) => {
 // into Windows Explorer, email clients, etc.
 ipcMain.handle('copy-file-to-clipboard', (_event: IpcMainInvokeEvent, filePath: string) => {
   const escaped = filePath.replace(/'/g, "''");
-  const cmd = `powershell -command "Set-Clipboard -Path '${escaped}'"`;
   return new Promise<{ ok: boolean; error?: string }>((resolve) => {
-    exec(cmd, (error: Error | null) => {
+    execFile('powershell', ['-command', `Set-Clipboard -Path '${escaped}'`], (error: Error | null) => {
       if (error) resolve({ ok: false, error: error.message });
       else resolve({ ok: true });
     });
@@ -404,16 +403,16 @@ _cleanupTempDownloads();
 setInterval(_cleanupTempDownloads, 60 * 60 * 1000);
 
 // Download a remote PDF to %TEMP%\ReamletDownloads and return the local path.
-// Follows up to 5 redirects. Rejects on HTTP errors or network failures.
+// Only follows HTTPS redirects (no HTTP downgrade). Rejects on HTTP errors or network failures.
 function downloadPdfToTemp(url: string, redirectsLeft = 5): Promise<string> {
   return new Promise((resolve, reject) => {
     if (redirectsLeft <= 0) { reject(new Error('Too many redirects')); return; }
+    if (!url.startsWith('https://')) { reject(new Error('Only HTTPS URLs are supported')); return; }
 
     const tempDir = path.join(os.tmpdir(), 'ReamletDownloads');
     try { fs.mkdirSync(tempDir, { recursive: true }); } catch { /* already exists */ }
 
-    const protocol = url.startsWith('https://') ? https : http;
-    const req = protocol.get(url, (res: NodeJS.ReadableStream & { statusCode: number; headers: Record<string, string> }) => {
+    const req = https.get(url, (res: NodeJS.ReadableStream & { statusCode: number; headers: Record<string, string> }) => {
       if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307 || res.statusCode === 308) {
         const location = res.headers['location'];
         if (location) {
@@ -436,7 +435,25 @@ function downloadPdfToTemp(url: string, redirectsLeft = 5): Promise<string> {
       const filePath = path.join(tempDir, fileName);
       const fileStream = fs.createWriteStream(filePath);
       res.pipe(fileStream);
-      fileStream.on('finish', () => { fileStream.close(); resolve(filePath); });
+      fileStream.on('finish', () => {
+        fileStream.close();
+        // Verify the file starts with the PDF magic bytes (%PDF-)
+        try {
+          const header = Buffer.alloc(5);
+          const fd = fs.openSync(filePath, 'r');
+          fs.readSync(fd, header, 0, 5, 0);
+          fs.closeSync(fd);
+          if (header.toString('ascii') !== '%PDF-') {
+            fs.unlinkSync(filePath);
+            reject(new Error('Downloaded file is not a valid PDF'));
+            return;
+          }
+        } catch (err) {
+          reject(err);
+          return;
+        }
+        resolve(filePath);
+      });
       fileStream.on('error', reject);
     });
     req.on('error', reject);

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@
 import type { BrowserWindow as BW, NativeImage, IpcMainInvokeEvent, IpcMainEvent, Event as ElectronEvent } from 'electron';
 
 const { app, BrowserWindow, ipcMain, dialog, Menu, nativeImage, shell } = require('electron');
-const { exec, execFile } = require('child_process');
+const { execFile } = require('child_process');
 const path  = require('path');
 const fs    = require('fs');
 const os    = require('os');
@@ -237,9 +237,12 @@ ipcMain.handle('open-printer-preferences', async (event: IpcMainInvokeEvent, pri
   const printers = await event.sender.getPrintersAsync();
   const valid = printers.some((p: { name: string }) => p.name === printerName);
   if (!valid) return { ok: false, error: 'Unknown printer.' };
-  const safe = printerName.replace(/["]/g, '');
-  exec(`rundll32 printui.dll,PrintUIEntry /e /n "${safe}"`);
-  return { ok: true };
+  return new Promise<{ ok: boolean; error?: string }>((resolve) => {
+    execFile('rundll32', ['printui.dll,PrintUIEntry', '/e', '/n', printerName], (error: Error | null) => {
+      if (error) resolve({ ok: false, error: error.message });
+      else resolve({ ok: true });
+    });
+  });
 });
 
 // Open a visible print preview window where the user can configure and execute printing.

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,8 @@ function buildMenu(): void {
         { label: 'Save',        accelerator: 'CmdOrCtrl+S',       click: () => fw()?.webContents.send('menu-save') },
         { label: 'Save Copy…',  accelerator: 'CmdOrCtrl+Shift+S', click: () => fw()?.webContents.send('menu-save-copy') },
         { type: 'separator' },
+        { label: 'Print…',          accelerator: 'CmdOrCtrl+P',           click: () => fw()?.webContents.send('menu-print') },
+        { type: 'separator' },
         { label: 'Close Tab',       accelerator: 'CmdOrCtrl+W',           click: () => fw()?.webContents.send('menu-close-tab') },
         { label: 'Reopen Closed Tab', accelerator: 'CmdOrCtrl+Shift+T',  click: () => fw()?.webContents.send('menu-reopen-tab') },
         { type: 'separator' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -428,14 +428,17 @@ function downloadPdfToTemp(url: string, redirectsLeft = 5): Promise<string> {
         return;
       }
 
-      let fileName: string;
+      let baseName: string;
       try {
         const base = path.basename(new URL(url).pathname) || 'download';
-        fileName = base.toLowerCase().endsWith('.pdf') ? base : `${base}.pdf`;
+        baseName = base.toLowerCase().endsWith('.pdf') ? base : `${base}.pdf`;
       } catch {
-        fileName = 'download.pdf';
+        baseName = 'download.pdf';
       }
-      const filePath = path.join(tempDir, fileName);
+      // Prefix with a random token to prevent concurrent downloads of the same
+      // URL from racing to write the same temp file.
+      const token    = Math.random().toString(36).slice(2, 10);
+      const filePath = path.join(tempDir, `${token}-${baseName}`);
       const fileStream = fs.createWriteStream(filePath);
       res.pipe(fileStream);
       fileStream.on('finish', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,6 +234,18 @@ ipcMain.handle('reveal-in-explorer', (_event: IpcMainInvokeEvent, filePath: stri
   return { ok: true };
 });
 
+// Return the list of system printers from the print preview window's web contents
+ipcMain.handle('get-printers', async (event: IpcMainInvokeEvent) => {
+  return event.sender.getPrintersAsync();
+});
+
+// Open the Windows printer preferences dialog for the given printer
+ipcMain.handle('open-printer-preferences', (_event: IpcMainInvokeEvent, printerName: string) => {
+  const safe = printerName.replace(/["]/g, '');
+  exec(`rundll32 printui.dll,PrintUIEntry /e /n "${safe}"`);
+  return { ok: true };
+});
+
 // Open a visible print preview window where the user can configure and execute printing.
 ipcMain.handle('open-print-preview', async (_event: IpcMainInvokeEvent, filePath: string): Promise<{ ok: boolean; error?: string }> => {
   if (!filePath || !fs.existsSync(filePath)) return { ok: false, error: 'File not found.' };
@@ -261,15 +273,33 @@ ipcMain.handle('open-print-preview', async (_event: IpcMainInvokeEvent, filePath
   return { ok: true };
 });
 
-// Execute the print dialog from the preview window's renderer process.
-ipcMain.handle('execute-print', (_event: IpcMainInvokeEvent, options: { copies: number; color: boolean; scaleFactor: number }): Promise<{ ok: boolean; error?: string }> => {
+// Execute a silent print (no system dialog) from the preview window's renderer process.
+ipcMain.handle('execute-print', (_event: IpcMainInvokeEvent, options: {
+  deviceName:  string;
+  copies:      number;
+  color:       boolean;
+  collate:     boolean;
+  duplexMode:  'simplex' | 'longEdge' | 'shortEdge';
+  scaleFactor: number;
+  landscape:   boolean;
+}): Promise<{ ok: boolean; error?: string }> => {
   const win = BrowserWindow.fromWebContents(_event.sender);
   if (!win) return Promise.resolve({ ok: false, error: 'No window.' });
 
   return new Promise(resolve => {
     win.webContents.print(
-      { silent: false, copies: options.copies, color: options.color, scaleFactor: options.scaleFactor },
-      (success: boolean, errorType: string) => resolve(success ? { ok: true } : { ok: false, error: errorType })
+      {
+        silent:      true,
+        deviceName:  options.deviceName,
+        copies:      options.copies,
+        color:       options.color,
+        collate:     options.collate,
+        duplexMode:  options.duplexMode,
+        scaleFactor: options.scaleFactor,
+        landscape:   options.landscape,
+      },
+      (success: boolean, errorType: string) =>
+        resolve(success ? { ok: true } : { ok: false, error: errorType })
     );
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,16 +124,8 @@ ipcMain.handle('open-file-dialog', async (event: IpcMainInvokeEvent) => {
   }));
 });
 
-ipcMain.handle('save-file', async (event: IpcMainInvokeEvent, filePath: string, arrayBuffer: ArrayBuffer) => {
+ipcMain.handle('save-file', async (_event: IpcMainInvokeEvent, filePath: string, arrayBuffer: ArrayBuffer) => {
   if (!filePath) return { ok: false, error: 'no file path' };
-  const win = BrowserWindow.fromWebContents(event.sender);
-  const { response } = await dialog.showMessageBox(win, {
-    type: 'question', buttons: ['Replace', 'Cancel'],
-    defaultId: 0, cancelId: 1,
-    title: 'Save', message: `Replace "${path.basename(filePath)}"?`,
-    detail: 'The existing file will be overwritten with your annotated version.',
-  });
-  if (response !== 0) return { ok: false, error: 'cancelled' };
   try {
     fs.writeFileSync(filePath, Buffer.from(arrayBuffer));
     return { ok: true };

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,17 +234,27 @@ ipcMain.handle('reveal-in-explorer', (_event: IpcMainInvokeEvent, filePath: stri
   return { ok: true };
 });
 
-// Open the PDF file in a hidden Chromium window and invoke the system print dialog.
+// Open the PDF file in a Chromium window and invoke the system print dialog.
 // This bypasses the canvas renderer entirely so the output is always correct.
 ipcMain.handle('print-pdf', async (_event: IpcMainInvokeEvent, filePath: string): Promise<{ ok: boolean; error?: string }> => {
   if (!filePath || !fs.existsSync(filePath)) return { ok: false, error: 'File not found.' };
 
   const printWin: BW = new BrowserWindow({
     show: false,
+    skipTaskbar: true,
     webPreferences: { nodeIntegration: false, contextIsolation: true },
   });
 
   await printWin.loadURL('file:///' + filePath.replace(/\\/g, '/'));
+
+  // Chromium skips GPU compositing for windows that are never shown, producing blank
+  // print output. Show the window (without stealing focus) so the PDF viewer renders,
+  // then wait for the PDF title update which signals the viewer has finished loading.
+  printWin.showInactive();
+  await new Promise<void>(resolve => {
+    const tid = setTimeout(resolve, 3000);
+    printWin.webContents.once('page-title-updated', () => { clearTimeout(tid); resolve(); });
+  });
 
   return new Promise(resolve => {
     printWin.webContents.print({ silent: false }, (success: boolean, errorType: string) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,6 +234,26 @@ ipcMain.handle('reveal-in-explorer', (_event: IpcMainInvokeEvent, filePath: stri
   return { ok: true };
 });
 
+// Open the PDF file in a hidden Chromium window and invoke the system print dialog.
+// This bypasses the canvas renderer entirely so the output is always correct.
+ipcMain.handle('print-pdf', async (_event: IpcMainInvokeEvent, filePath: string): Promise<{ ok: boolean; error?: string }> => {
+  if (!filePath || !fs.existsSync(filePath)) return { ok: false, error: 'File not found.' };
+
+  const printWin: BW = new BrowserWindow({
+    show: false,
+    webPreferences: { nodeIntegration: false, contextIsolation: true },
+  });
+
+  await printWin.loadURL('file:///' + filePath.replace(/\\/g, '/'));
+
+  return new Promise(resolve => {
+    printWin.webContents.print({ silent: false }, (success: boolean, errorType: string) => {
+      printWin.destroy();
+      resolve(success ? { ok: true } : { ok: false, error: errorType });
+    });
+  });
+});
+
 // Read / write the extension ID in the native messaging host manifest.
 // The manifest lives next to the Reamlet exe (installed and portable builds).
 function getManifestPath(): string {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -61,6 +61,9 @@ contextBridge.exposeInMainWorld('api', {
   // Show the file in its containing folder
   revealInExplorer: (filePath: string) => ipcRenderer.invoke('reveal-in-explorer', filePath),
 
+  // Print the PDF file directly via the system print dialog
+  printPdf: (filePath: string) => ipcRenderer.invoke('print-pdf', filePath),
+
   // Initiate a native OS file drag (for dragging into Outlook, Explorer, etc.)
   startDrag: (filePath: string) => ipcRenderer.send('start-drag', filePath),
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -61,17 +61,22 @@ contextBridge.exposeInMainWorld('api', {
   // Show the file in its containing folder
   revealInExplorer: (filePath: string) => ipcRenderer.invoke('reveal-in-explorer', filePath),
 
-  // Open a visible print preview window for the given PDF file
-  openPrintPreview: (filePath: string) => ipcRenderer.invoke('open-print-preview', filePath),
-
-  // Receive PDF data pushed from main into the print preview window
-  onPdfData: (callback: (data: { buffer: ArrayBuffer }) => void) => {
+  // Print preview APIs
+  openPrintPreview:       (filePath: string) => ipcRenderer.invoke('open-print-preview', filePath),
+  onPdfData:              (callback: (data: { buffer: ArrayBuffer }) => void) => {
     ipcRenderer.on('pdf-data', (_e: unknown, data: { buffer: ArrayBuffer }) => callback(data));
   },
-
-  // Trigger the system print dialog from the preview window
-  executePrint: (options: { copies: number; color: boolean; scaleFactor: number }) =>
-    ipcRenderer.invoke('execute-print', options),
+  getPrinters:            () => ipcRenderer.invoke('get-printers'),
+  openPrinterPreferences: (printerName: string) => ipcRenderer.invoke('open-printer-preferences', printerName),
+  executePrint: (options: {
+    deviceName:  string;
+    copies:      number;
+    color:       boolean;
+    collate:     boolean;
+    duplexMode:  string;
+    scaleFactor: number;
+    landscape:   boolean;
+  }) => ipcRenderer.invoke('execute-print', options),
 
   // Initiate a native OS file drag (for dragging into Outlook, Explorer, etc.)
   startDrag: (filePath: string) => ipcRenderer.send('start-drag', filePath),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -41,7 +41,7 @@ contextBridge.exposeInMainWorld('api', {
 
   // Subscribe to menu events
   onMenuEvent: (callback: (event: string) => void) => {
-    ['menu-open', 'menu-save', 'menu-save-copy', 'menu-close-tab', 'menu-reopen-tab', 'menu-extension-id']
+    ['menu-open', 'menu-save', 'menu-save-copy', 'menu-print', 'menu-close-tab', 'menu-reopen-tab', 'menu-extension-id']
       .forEach(ev => ipcRenderer.on(ev, () => callback(ev)));
   },
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -61,8 +61,17 @@ contextBridge.exposeInMainWorld('api', {
   // Show the file in its containing folder
   revealInExplorer: (filePath: string) => ipcRenderer.invoke('reveal-in-explorer', filePath),
 
-  // Print the PDF file directly via the system print dialog
-  printPdf: (filePath: string) => ipcRenderer.invoke('print-pdf', filePath),
+  // Open a visible print preview window for the given PDF file
+  openPrintPreview: (filePath: string) => ipcRenderer.invoke('open-print-preview', filePath),
+
+  // Receive PDF data pushed from main into the print preview window
+  onPdfData: (callback: (data: { buffer: ArrayBuffer }) => void) => {
+    ipcRenderer.on('pdf-data', (_e: unknown, data: { buffer: ArrayBuffer }) => callback(data));
+  },
+
+  // Trigger the system print dialog from the preview window
+  executePrint: (options: { copies: number; color: boolean; scaleFactor: number }) =>
+    ipcRenderer.invoke('execute-print', options),
 
   // Initiate a native OS file drag (for dragging into Outlook, Explorer, etc.)
   startDrag: (filePath: string) => ipcRenderer.send('start-drag', filePath),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -73,7 +73,7 @@ contextBridge.exposeInMainWorld('api', {
     copies:      number;
     color:       boolean;
     collate:     boolean;
-    duplexMode:  string;
+    duplexMode:  'simplex' | 'longEdge' | 'shortEdge';
     scaleFactor: number;
     landscape:   boolean;
   }) => ipcRenderer.invoke('execute-print', options),

--- a/src/renderer/annotator.ts
+++ b/src/renderer/annotator.ts
@@ -117,6 +117,38 @@ export class Annotator {
     this.pages.forEach((p, idx) => this._redrawPage(p, idx + 1));
   }
 
+  /**
+   * Transform stored annotation coordinates to match a 90° CW rotation applied
+   * to the given page (or all pages when pageNum is null).
+   * Must be called before redrawAll() / page re-render after rotation.
+   */
+  rotateAnnotations(pageNum: number | null, cwDegrees: number) {
+    const steps = (Math.round(cwDegrees / 90) % 4 + 4) % 4;
+    const targets = this.annotations.filter(a => pageNum === null || a.pageNum === pageNum);
+    for (let s = 0; s < steps; s++) {
+      for (const ann of targets) {
+        if (ann.type === 'draw' || ann.type === 'freeHighlight') {
+          ann.points = (ann.points as [number, number][]).map(([nx, ny]) => [1 - ny, nx]);
+        } else if (ann.type === 'highlight') {
+          ann.rects = ann.rects.map(r => ({
+            x: 1 - (r.y + r.height),
+            y: r.x,
+            width: r.height,
+            height: r.width,
+          }));
+        } else if (ann.type === 'text') {
+          const { x, y } = ann;
+          ann.x = 1 - y;
+          ann.y = x;
+        } else if (ann.type === 'line' || ann.type === 'arrow' || ann.type === 'rect' || ann.type === 'oval') {
+          const { x1, y1, x2, y2 } = ann;
+          ann.x1 = 1 - y1; ann.y1 = x1;
+          ann.x2 = 1 - y2; ann.y2 = x2;
+        }
+      }
+    }
+  }
+
   undo() {
     if (this._histIdx <= 0) return;
     this._histIdx--;

--- a/src/renderer/annotator.ts
+++ b/src/renderer/annotator.ts
@@ -27,8 +27,7 @@ export class Annotator {
   _dragOrigAnn: Annotation | null;
   _dragPageRect: DOMRect | null;
   _clipboard: Annotation | null;
-  _history: string[];
-  _histIdx: number;
+  onCommit?: () => void;
   _handlers: Record<number, unknown>;
   _docMouseupHighlight!: (e: MouseEvent) => void;
   _docMousemoveDrag!: (e: MouseEvent) => void;
@@ -71,9 +70,6 @@ export class Annotator {
     this._lastCursorPageNum = null;
     this._lastCursorNorm    = null;
 
-    this._history = ['[]'];
-    this._histIdx = 0;
-
     this._handlers = {};
     this._attachAll();
   }
@@ -109,8 +105,6 @@ export class Annotator {
       const ctx = p.annotCanvas.getContext('2d')!;
       ctx.clearRect(0, 0, p.annotCanvas.width, p.annotCanvas.height);
     });
-    this._history = ['[]'];
-    this._histIdx = 0;
   }
 
   redrawAll() {
@@ -149,20 +143,9 @@ export class Annotator {
     }
   }
 
-  undo() {
-    if (this._histIdx <= 0) return;
-    this._histIdx--;
+  setAnnotations(json: string) {
     this._clearSelection(false);
-    const data = JSON.parse(this._history[this._histIdx]);
-    this.annotations.splice(0, this.annotations.length, ...data);
-    this.redrawAll();
-  }
-
-  redo() {
-    if (this._histIdx >= this._history.length - 1) return;
-    this._histIdx++;
-    this._clearSelection(false);
-    const data = JSON.parse(this._history[this._histIdx]);
+    const data = JSON.parse(json) as Annotation[];
     this.annotations.splice(0, this.annotations.length, ...data);
     this.redrawAll();
   }
@@ -988,8 +971,6 @@ export class Annotator {
   // ── Undo / redo history ──────────────────────────────────────
 
   _pushHistory() {
-    this._history.splice(this._histIdx + 1);
-    this._history.push(JSON.stringify([...this.annotations]));
-    this._histIdx++;
+    this.onCommit?.();
   }
 }

--- a/src/renderer/annotator.ts
+++ b/src/renderer/annotator.ts
@@ -138,6 +138,11 @@ export class Annotator {
           const { x1, y1, x2, y2 } = ann;
           ann.x1 = 1 - y1; ann.y1 = x1;
           ann.x2 = 1 - y2; ann.y2 = x2;
+        } else {
+          // Runtime guard: if a new Annotation type is added without a
+          // corresponding branch here, warn rather than silently skip rotation
+          // and leave coordinates in an inconsistent state.
+          console.warn('rotateAnnotations: unhandled annotation type:', (ann as { type: unknown }).type);
         }
       }
     }

--- a/src/renderer/annotator.ts
+++ b/src/renderer/annotator.ts
@@ -219,7 +219,7 @@ export class Annotator {
             pageNum:   fh.pageNum,
             points:    fh.points,
             color:     this.color,
-            thickness: 20,
+            thickness: 20 / (this.viewer?.scale ?? 1),
           });
           this._pushHistory();
         }
@@ -341,12 +341,13 @@ export class Annotator {
         this._drawing = false;
         if (this._currentPath && this._currentPath.points.length > 1) {
           const w = canvas.width, h = canvas.height;
+          const scale = this.viewer?.scale ?? 1;
           this.annotations.push({
             type:      'draw',
             pageNum,
             points:    this._currentPath.points.map(([x, y]) => [x / w, y / h]),
             color:     this._currentPath.color,
-            thickness: this._currentPath.thickness,
+            thickness: this._currentPath.thickness / scale,
           });
           this._pushHistory();
         }
@@ -358,12 +359,13 @@ export class Annotator {
         this._shapeStart = null;
         if (Math.abs(x2 - x1) > 2 || Math.abs(y2 - y1) > 2) {
           const w = canvas.width, h = canvas.height;
+          const scale = this.viewer?.scale ?? 1;
           this.annotations.push({
             type: this.tool as ShapeAnnotation['type'], pageNum,
             x1: x1 / w, y1: y1 / h,
             x2: x2 / w, y2: y2 / h,
             color:     this.color,
-            thickness: this.thickness,
+            thickness: this.thickness / scale,
           });
           this._pushHistory();
         }
@@ -399,12 +401,13 @@ export class Annotator {
       this._drawing = false;
       if (this._currentPath && this._currentPath.points.length > 1) {
         const w = canvas.width, h = canvas.height;
+        const scale = this.viewer?.scale ?? 1;
         this.annotations.push({
           type:      'draw',
           pageNum,
           points:    this._currentPath.points.map(([x, y]) => [x / w, y / h]),
           color:     this._currentPath.color,
-          thickness: this._currentPath.thickness,
+          thickness: this._currentPath.thickness / scale,
         });
         this._pushHistory();
       }
@@ -864,10 +867,11 @@ export class Annotator {
   }
 
   _drawAnnotation(ctx: CanvasRenderingContext2D, annot: Annotation, w: number, h: number) {
+    const scale = this.viewer?.scale ?? 1;
     ctx.save();
     if (annot.type === 'draw') {
       ctx.strokeStyle = annot.color;
-      ctx.lineWidth   = annot.thickness;
+      ctx.lineWidth   = annot.thickness * scale;
       ctx.lineCap     = 'round';
       ctx.lineJoin    = 'round';
       ctx.beginPath();
@@ -880,7 +884,7 @@ export class Annotator {
     } else if (annot.type === 'freeHighlight') {
       ctx.globalAlpha = 0.35;
       ctx.strokeStyle = annot.color;
-      ctx.lineWidth   = annot.thickness;
+      ctx.lineWidth   = annot.thickness * scale;
       ctx.lineCap     = 'round';
       ctx.lineJoin    = 'round';
       ctx.beginPath();
@@ -915,7 +919,7 @@ export class Annotator {
 
     } else if (annot.type === 'line' || annot.type === 'rect' || annot.type === 'oval' || annot.type === 'arrow') {
       ctx.strokeStyle = annot.color;
-      ctx.lineWidth   = annot.thickness;
+      ctx.lineWidth   = annot.thickness * scale;
       ctx.lineCap     = 'round';
       ctx.lineJoin    = 'round';
       this._drawShape(ctx, annot.type, annot.x1 * w, annot.y1 * h, annot.x2 * w, annot.y2 * h);

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1981,7 +1981,6 @@ async function _executeReorder() {
   pages.forEach(p => resultDoc.addPage(p));
   const bytes = await resultDoc.save();
 
-  _pushUndo(tab);
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   // Re-add loading overlay for the re-render
@@ -2106,7 +2105,6 @@ async function _executeFooter() {
   const tab   = activeTab;
   const bytes = await embedFooter(tab.pdfBytes, { left, center, right, fontSize });
 
-  _pushUndo(tab);
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   const reloadEl = document.createElement('div');
@@ -2196,7 +2194,6 @@ async function _executeWatermark() {
   const tab   = activeTab;
   const bytes = await embedWatermark(tab.pdfBytes, { text, fontSize, opacity, angle });
 
-  _pushUndo(tab);
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   const reloadEl = document.createElement('div');

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1314,6 +1314,51 @@ document.getElementById('btn-fit-h')!.addEventListener('click',  fitHeight);
 document.getElementById('btn-rotate')!.addEventListener('click', (e) => rotate(e.shiftKey));
 document.getElementById('btn-print')!.addEventListener('click',  () => window.print());
 
+// ── TEMPORARY PRINT DEBUG ──────────────────────────────────────
+{
+  const dbgEl = document.createElement('div');
+  dbgEl.id = 'print-debug-overlay';
+  dbgEl.style.cssText = 'display:none;position:fixed;top:0;left:0;background:yellow;color:black;font:12px monospace;padding:8px;z-index:9999;white-space:pre;';
+  document.body.appendChild(dbgEl);
+
+  window.addEventListener('beforeprint', () => {
+    const lines: string[] = [];
+    lines.push(`window inner: ${window.innerWidth}x${window.innerHeight}`);
+    lines.push(`devicePixelRatio: ${window.devicePixelRatio}`);
+
+    const wrappers = document.querySelectorAll<HTMLElement>('.page-wrapper');
+    lines.push(`page-wrapper count: ${wrappers.length}`);
+
+    wrappers.forEach((wrapper, i) => {
+      const cs = getComputedStyle(wrapper);
+      lines.push(`\nwrapper[${i}]:`);
+      lines.push(`  inline style: w=${wrapper.style.width} h=${wrapper.style.height}`);
+      lines.push(`  computed:     w=${cs.width} h=${cs.height}`);
+      lines.push(`  opacity: inline=${wrapper.style.opacity} computed=${cs.opacity}`);
+
+      wrapper.querySelectorAll<HTMLCanvasElement>('canvas').forEach((c, j) => {
+        const cc = getComputedStyle(c);
+        let hasContent = false;
+        try {
+          const px = c.getContext('2d')?.getImageData(c.width >> 1, c.height >> 1, 1, 1).data;
+          hasContent = !!px && px[3] > 0;
+        } catch { /* tainted or no context */ }
+        lines.push(`  canvas[${j}] .${c.className}: attr=${c.width}x${c.height} computed=${cc.width}x${cc.height} hasContent=${hasContent}`);
+      });
+    });
+
+    const text = lines.join('\n');
+    console.log('[PRINT DEBUG]\n' + text);
+    dbgEl.textContent = text;
+    dbgEl.style.display = 'block';
+  });
+
+  window.addEventListener('afterprint', () => {
+    dbgEl.style.display = 'none';
+  });
+}
+// ── END PRINT DEBUG ────────────────────────────────────────────
+
 btnBold.addEventListener('click', () => {
   if (!activeTab?.annotator) return;
   const next = !activeTab.annotator.textBold;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1746,7 +1746,7 @@ inputCtxMenu.addEventListener('mousedown', (e) => {
     case 'paste':
       navigator.clipboard.readText().then(text => {
         input.setRangeText(text, input.selectionStart ?? 0, input.selectionEnd ?? 0, 'end');
-      });
+      }).catch(() => { /* clipboard access denied — nothing to paste */ });
       break;
   }
 });

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -87,6 +87,7 @@ const colorDot       = document.getElementById('color-dot')!;
 const colorPanel     = document.getElementById('color-panel')!;
 const titleFilename  = document.getElementById('title-filename')!;
 const contextMenu    = document.getElementById('context-menu')!;
+const inputCtxMenu   = document.getElementById('input-ctx-menu')!;
 const ctxCut         = document.querySelector('[data-ctx="cut"]')   as HTMLButtonElement;
 const ctxPaste       = document.querySelector('[data-ctx="paste"]') as HTMLButtonElement;
 const tabContextMenu = document.getElementById('tab-context-menu')!;
@@ -287,6 +288,7 @@ viewerHost.addEventListener('contextmenu', (e) => {
 document.addEventListener('mousedown', (e) => {
   if (!(e.target as Element)?.closest('#context-menu'))     _hideContextMenu();
   if (!(e.target as Element)?.closest('#tab-context-menu')) _hideTabContextMenu();
+  if (!(e.target as Element)?.closest('#input-ctx-menu'))   inputCtxMenu.classList.add('hidden');
 });
 
 contextMenu.addEventListener('mousedown', (e) => {
@@ -1309,6 +1311,8 @@ document.addEventListener('keydown', async (e) => {
   if (ctrl && (e.key === '=' || e.key === '+')) { e.preventDefault(); zoom(0.1); return; }
   if (ctrl && e.key === '-') { e.preventDefault(); zoom(-0.1); return; }
   if (ctrl && e.key === '0') { e.preventDefault(); fitWidth(); return; }
+  if (document.activeElement?.tagName === 'INPUT' || document.activeElement?.tagName === 'TEXTAREA') return;
+
   if (ctrl && e.key === 'z') { e.preventDefault(); activeTab?.annotator?.undo(); return; }
   if (ctrl && (e.key === 'y' || (e.shiftKey && e.key === 'Z'))) { e.preventDefault(); activeTab?.annotator?.redo(); return; }
   if (ctrl && e.key === 'x') { e.preventDefault(); activeTab?.annotator?.cut(); return; }
@@ -1435,6 +1439,41 @@ document.getElementById('ext-id-save')!.addEventListener('click', async () => {
     document.getElementById('ext-id-modal')!.classList.add('hidden');
   } else {
     alert('Failed to save: ' + result.error);
+  }
+});
+
+document.getElementById('ext-id-input')!.addEventListener('contextmenu', (e) => {
+  e.preventDefault();
+  e.stopPropagation();
+  inputCtxMenu.classList.remove('hidden');
+  const menuW = inputCtxMenu.offsetWidth  || 120;
+  const menuH = inputCtxMenu.offsetHeight || 80;
+  inputCtxMenu.style.left = `${Math.max(0, Math.min(e.clientX, window.innerWidth  - menuW - 4))}px`;
+  inputCtxMenu.style.top  = `${Math.max(0, Math.min(e.clientY, window.innerHeight - menuH - 4))}px`;
+});
+
+inputCtxMenu.addEventListener('mousedown', (e) => {
+  const btn = (e.target as Element)?.closest('[data-input-ctx]') as HTMLElement | null;
+  if (!btn) return;
+  e.preventDefault();
+  inputCtxMenu.classList.add('hidden');
+  const input = document.getElementById('ext-id-input') as HTMLInputElement;
+  input.focus();
+  const start = input.selectionStart ?? 0;
+  const end   = input.selectionEnd   ?? 0;
+  switch (btn.dataset.inputCtx) {
+    case 'cut':
+      navigator.clipboard.writeText(input.value.substring(start, end));
+      input.setRangeText('', start, end, 'end');
+      break;
+    case 'copy':
+      navigator.clipboard.writeText(input.value.substring(start, end));
+      break;
+    case 'paste':
+      navigator.clipboard.readText().then(text => {
+        input.setRangeText(text, input.selectionStart ?? 0, input.selectionEnd ?? 0, 'end');
+      });
+      break;
   }
 });
 

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -845,6 +845,8 @@ async function _loadTabContent(tab: Tab) {
     tab.annotator = new Annotator(tab.viewer.pages, tab.viewer);
     _patchAnnotatorForDirty(tab);
     _pushUndo(tab);
+    // Mark the initial loaded state as clean (only on first open, not after PDF ops or undo).
+    if (tab._undoCleanIdx === undefined) tab._undoCleanIdx = tab._undoIdx!;
     tab.outline = await tab.viewer.getOutline();
   } catch (err) {
     const name = tab.filePath ? tab.filePath.split(/[\\/]/).pop() : 'file';
@@ -941,9 +943,10 @@ async function saveTab(tab: Tab | null) {
     if (choice !== 0) return false;
     const res = await window.api.saveFile(tab.filePath, bytes.buffer as ArrayBuffer);
     if (res.ok) {
-      tab.pdfBytes     = bytes;
-      tab._savedBytes  = null;
-      tab.dirty        = false;
+      tab.pdfBytes       = bytes;
+      tab._savedBytes    = null;
+      tab._undoCleanIdx  = tab._undoIdx ?? null;
+      tab.dirty          = false;
       renderTabBar();
       return true;
     } else if (res.error && res.error !== 'cancelled') {
@@ -963,6 +966,7 @@ async function saveTab(tab: Tab | null) {
     tab._suggestedName = null;
     tab.pdfBytes       = bytes;
     tab._savedBytes    = null;
+    tab._undoCleanIdx  = tab._undoIdx ?? null;
     tab.dirty          = false;
     renderTabBar();
     updateTitleBar(tab);
@@ -995,6 +999,7 @@ async function saveTabCopy(tab: Tab | null) {
     tab._suggestedDir  = null;
     tab._suggestedName = null;
     tab.pdfBytes       = bytes;
+    tab._undoCleanIdx  = tab._undoIdx ?? null;
     tab.dirty          = false;
     renderTabBar();
     updateTitleBar(tab);
@@ -1122,10 +1127,31 @@ function _pushUndo(tab: Tab): void {
   if (_undoing) return;
   const annotations = tab.annotator ? JSON.stringify(tab.annotator.annotations) : '[]';
   if (!tab._undoStack) { tab._undoStack = []; tab._undoIdx = -1; }
-  tab._undoStack.splice(tab._undoIdx! + 1);
+  // Truncate forward history. If the clean state is in the discarded future, mark it unreachable.
+  const nextIdx = tab._undoIdx! + 1;
+  if (tab._undoStack.length > nextIdx) {
+    if (tab._undoCleanIdx != null && tab._undoCleanIdx > tab._undoIdx!) tab._undoCleanIdx = null;
+    tab._undoStack.splice(nextIdx);
+  }
   tab._undoStack.push({ pdfBytes: tab.pdfBytes, annotations });
-  if (tab._undoStack.length > UNDO_LIMIT) tab._undoStack.shift();
+  // Enforce limit. If the oldest entry is dropped, shift the clean index down with it.
+  if (tab._undoStack.length > UNDO_LIMIT) {
+    tab._undoStack.shift();
+    if (tab._undoCleanIdx != null) {
+      tab._undoCleanIdx--;
+      if (tab._undoCleanIdx < 0) tab._undoCleanIdx = null; // clean entry was dropped
+    }
+  }
   tab._undoIdx = tab._undoStack.length - 1;
+}
+
+function _syncDirtyToUndo(tab: Tab): void {
+  if (tab._undoCleanIdx != null && tab._undoIdx === tab._undoCleanIdx) {
+    tab.dirty = false;
+    renderTabBar();
+  } else {
+    markDirty(tab);
+  }
 }
 
 async function _applyUndo(tab: Tab, entry: { pdfBytes: Uint8Array; annotations: string }): Promise<void> {
@@ -1149,7 +1175,7 @@ async function _applyUndo(tab: Tab, entry: { pdfBytes: Uint8Array; annotations: 
   } else {
     tab.annotator?.setAnnotations(entry.annotations);
   }
-  markDirty(tab);
+  _syncDirtyToUndo(tab);
 }
 
 // ── Zoom ───────────────────────────────────────────────────────

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1946,7 +1946,7 @@ function _drawFooterPreview() {
 
   // Footer text
   const pdfFontSize  = parseFloat((document.getElementById('footer-fontsize') as HTMLInputElement).value) || 10;
-  const canvasFontSize = Math.max(9, Math.min(16, pdfFontSize * pw / 280));
+  const canvasFontSize = pdfFontSize * pw / 612; // proportional to letter page width (612pt)
   ctx.font      = `${canvasFontSize}px Helvetica, Arial, sans-serif`;
   ctx.fillStyle = '#222222';
   const textY = sepY + 17;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -927,8 +927,17 @@ async function saveTab(tab: Tab | null) {
 
   const bytes = await embedAnnotations(tab.pdfBytes, annotations, viewer);
 
-  // Real on-disk file: overwrite after confirmation.
+  // Real on-disk file: confirm overwrite, then save.
   if (tab.filePath && /[\\/]/.test(tab.filePath)) {
+    const name   = tab.filePath.replace(/.*[\\/]/, '');
+    const choice = await showDialog({
+      title:     'Save',
+      message:   `Replace "${name}"?`,
+      buttons:   ['Replace', 'Cancel'],
+      defaultId: 0,
+      cancelId:  1,
+    });
+    if (choice !== 0) return false;
     const res = await window.api.saveFile(tab.filePath, bytes.buffer as ArrayBuffer);
     if (res.ok) {
       tab.pdfBytes     = bytes;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -2028,12 +2028,15 @@ function _drawWatermarkPreview() {
   ctx.fillStyle = '#ffffff';
   ctx.fillRect(mx, my, pw, ph);
 
-  const text     = (document.getElementById('watermark-text')     as HTMLInputElement).value.trim() || 'Preview';
+  const rawText  = (document.getElementById('watermark-text')     as HTMLTextAreaElement).value;
   const pdfSize  = parseFloat((document.getElementById('watermark-fontsize') as HTMLInputElement).value) || 72;
   const opacity  = parseFloat((document.getElementById('watermark-opacity')  as HTMLInputElement).value) / 100;
   const angle    = parseFloat((document.getElementById('watermark-angle')    as HTMLInputElement).value) || 0;
+  const lines    = rawText.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+  const preview  = lines.length > 0 ? lines : ['Preview'];
 
-  const canvasFs = Math.max(6, Math.round(pdfSize * pw / 612));
+  const canvasFs   = Math.max(6, Math.round(pdfSize * pw / 612));
+  const lineHeight = canvasFs * 1.3;
 
   ctx.save();
   ctx.globalAlpha  = opacity;
@@ -2043,7 +2046,10 @@ function _drawWatermarkPreview() {
   ctx.textBaseline = 'middle';
   ctx.translate(mx + pw / 2, my + ph / 2);
   ctx.rotate(-angle * Math.PI / 180); // negative to match pdf-lib CCW convention
-  ctx.fillText(text, 0, 0);
+  preview.forEach((line, i) => {
+    const yOffset = (i - (preview.length - 1) / 2) * lineHeight;
+    ctx.fillText(line, 0, yOffset);
+  });
   ctx.restore();
 }
 
@@ -2063,7 +2069,7 @@ _wmOpacityInput.addEventListener('input', () => {
   _wmOpacityVal.textContent = _wmOpacityInput.value + '%';
   _drawWatermarkPreview();
 });
-(document.getElementById('watermark-text')     as HTMLInputElement).addEventListener('input',  _drawWatermarkPreview);
+(document.getElementById('watermark-text')     as HTMLTextAreaElement).addEventListener('input',  _drawWatermarkPreview);
 (document.getElementById('watermark-fontsize') as HTMLInputElement).addEventListener('input',  _drawWatermarkPreview);
 (document.getElementById('watermark-angle')    as HTMLInputElement).addEventListener('input',  _drawWatermarkPreview);
 (document.getElementById('watermark-angle')    as HTMLInputElement).addEventListener('change', _drawWatermarkPreview);
@@ -2072,7 +2078,8 @@ async function _executeWatermark() {
   if (!activeTab) return;
   document.getElementById('watermark-modal')!.classList.add('hidden');
 
-  const text     = (document.getElementById('watermark-text')     as HTMLInputElement).value.trim();
+  const text     = (document.getElementById('watermark-text')     as HTMLTextAreaElement).value
+                    .split('\n').map(l => l.trim()).filter(l => l.length > 0).join('\n');
   const fontSize = parseFloat((document.getElementById('watermark-fontsize') as HTMLInputElement).value) || 72;
   const opacity  = parseFloat((document.getElementById('watermark-opacity')  as HTMLInputElement).value) / 100;
   const angle    = parseFloat((document.getElementById('watermark-angle')    as HTMLInputElement).value) || 0;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1079,21 +1079,38 @@ async function _applyZoomNow(scale: number) {
   _zoomTimer  = null;
   _zoomTarget = null;
 
-  const pagesEl = activeTab.pane.querySelector('.pdf-pages') as HTMLElement | null;
-  if (pagesEl) pagesEl.style.transform = '';
-
   const v        = activeTab.viewer;
   const pane     = activeTab.pane;
   const oldScale = v.scale;
   const cursor   = _zoomCursor;
   _zoomCursor    = null;
 
+  // Capture scroll snapshot before the CSS transform is removed so the
+  // pre-scroll and final-scroll calculations both use the committed position.
+  const prevScrollLeft = pane.scrollLeft;
+  const prevScrollTop  = pane.scrollTop;
+
+  const pagesEl = activeTab.pane.querySelector('.pdf-pages') as HTMLElement | null;
+  if (pagesEl) pagesEl.style.transform = '';
+
+  // Pre-scroll synchronously (before any await) so _getVisibleSet() inside
+  // setZoom renders the pages near the cursor first.
+  // Zoom-out: new scroll is smaller and always in bounds.
+  // Zoom-in: new scroll may exceed current max and is browser-clamped to the
+  //   bottom of the old layout, which is still far better than staying at 0.
+  if (cursor !== null) {
+    const ratio = scale / oldScale;
+    pane.scrollLeft = Math.max(0, (prevScrollLeft + cursor.x) * ratio - cursor.x);
+    pane.scrollTop  = Math.max(0, (prevScrollTop  + cursor.y) * ratio - cursor.y);
+  }
+
   await v.setZoom(scale);
 
+  // Final exact correction now that content is properly sized.
   if (cursor !== null) {
-    const ratio     = scale / oldScale;
-    pane.scrollLeft = (pane.scrollLeft + cursor.x) * ratio - cursor.x;
-    pane.scrollTop  = (pane.scrollTop  + cursor.y) * ratio - cursor.y;
+    const ratio = scale / oldScale;
+    pane.scrollLeft = Math.max(0, (prevScrollLeft + cursor.x) * ratio - cursor.x);
+    pane.scrollTop  = Math.max(0, (prevScrollTop  + cursor.y) * ratio - cursor.y);
   }
 
   activeTab.annotator!.pages = v.pages;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1066,6 +1066,7 @@ async function _applyZoomNow(scale: number) {
   await v.setZoom(scale);
   activeTab.annotator!.pages = v.pages;
   activeTab.annotator!.redrawAll();
+  activeTab.annotator!.setTool(activeTab.annotator!.tool);
   _syncScrollbar();
   _updateHorizontalPadding();
   _syncScrollbarH();
@@ -1098,6 +1099,7 @@ async function rotate(singlePage: boolean) {
   else            await v.rotateAll(90);
   activeTab.annotator!.pages = v.pages;
   activeTab.annotator!.redrawAll();
+  activeTab.annotator!.setTool(activeTab.annotator!.tool);
   markDirty(activeTab);
 }
 

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1891,9 +1891,95 @@ async function _executeReorder() {
 
 // ── Add Footer ─────────────────────────────────────────────────
 
+function _resolveFooterColForPreview(col: 'left' | 'center' | 'right'): string {
+  const sel    = document.getElementById(`footer-${col}-sel`)    as HTMLSelectElement;
+  const custom = document.getElementById(`footer-${col}-custom`) as HTMLInputElement;
+  const total  = activeTab?.viewer.pageCount ?? 10;
+  switch (sel.value) {
+    case 'date':       return new Date().toLocaleDateString();
+    case 'page':       return '1';
+    case 'page-total': return `1 / ${total}`;
+    case 'custom':     return custom.value;
+    default:           return '';
+  }
+}
+
+function _resolveFooterColForEmbed(col: 'left' | 'center' | 'right'): string {
+  const sel    = document.getElementById(`footer-${col}-sel`)    as HTMLSelectElement;
+  const custom = document.getElementById(`footer-${col}-custom`) as HTMLInputElement;
+  switch (sel.value) {
+    case 'date':       return new Date().toLocaleDateString();
+    case 'page':       return '{page}';
+    case 'page-total': return '{page} / {total}';
+    case 'custom':     return custom.value;
+    default:           return '';
+  }
+}
+
+function _drawFooterPreview() {
+  const canvas = document.getElementById('footer-preview') as HTMLCanvasElement;
+  const ctx    = canvas.getContext('2d')!;
+  const W = canvas.width, H = canvas.height;
+
+  ctx.clearRect(0, 0, W, H);
+  ctx.fillStyle = '#1e1e1e';
+  ctx.fillRect(0, 0, W, H);
+
+  // Page outline
+  const mx = 16, my = 10, pw = W - mx * 2, ph = H - my * 2;
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(mx, my, pw, ph);
+
+  // Simulated content lines
+  ctx.strokeStyle = '#e0e0e0';
+  ctx.lineWidth = 1;
+  for (let y = my + 10; y < my + ph - 34; y += 10) {
+    const lw = y < my + ph - 54 ? pw - 24 : (pw - 24) * 0.55;
+    ctx.beginPath(); ctx.moveTo(mx + 12, y); ctx.lineTo(mx + 12 + lw, y); ctx.stroke();
+  }
+
+  // Footer separator
+  const sepY = my + ph - 28;
+  ctx.strokeStyle = '#c0c0c0';
+  ctx.lineWidth = 0.5;
+  ctx.beginPath(); ctx.moveTo(mx + 8, sepY); ctx.lineTo(mx + pw - 8, sepY); ctx.stroke();
+
+  // Footer text
+  const pdfFontSize  = parseFloat((document.getElementById('footer-fontsize') as HTMLInputElement).value) || 10;
+  const canvasFontSize = Math.max(9, Math.min(16, pdfFontSize * pw / 280));
+  ctx.font      = `${canvasFontSize}px Helvetica, Arial, sans-serif`;
+  ctx.fillStyle = '#222222';
+  const textY = sepY + 17;
+
+  const lText = _resolveFooterColForPreview('left');
+  const cText = _resolveFooterColForPreview('center');
+  const rText = _resolveFooterColForPreview('right');
+
+  if (lText) { ctx.textAlign = 'left';   ctx.fillText(lText, mx + 10,      textY); }
+  if (cText) { ctx.textAlign = 'center'; ctx.fillText(cText, mx + pw / 2,  textY); }
+  if (rText) { ctx.textAlign = 'right';  ctx.fillText(rText, mx + pw - 10, textY); }
+  ctx.textAlign = 'left';
+}
+
+function _setupFooterColSelect(col: 'left' | 'center' | 'right') {
+  const sel    = document.getElementById(`footer-${col}-sel`)    as HTMLSelectElement;
+  const custom = document.getElementById(`footer-${col}-custom`) as HTMLInputElement;
+  sel.addEventListener('change', () => {
+    custom.classList.toggle('footer-custom-hidden', sel.value !== 'custom');
+    _drawFooterPreview();
+  });
+  custom.addEventListener('input', _drawFooterPreview);
+}
+
+_setupFooterColSelect('left');
+_setupFooterColSelect('center');
+_setupFooterColSelect('right');
+(document.getElementById('footer-fontsize') as HTMLInputElement).addEventListener('input', _drawFooterPreview);
+
 document.getElementById('btn-footer')!.addEventListener('click', () => {
   if (!activeTab) return;
   document.getElementById('footer-modal')!.classList.remove('hidden');
+  _drawFooterPreview();
 });
 document.getElementById('footer-cancel')!.addEventListener('click', () => {
   document.getElementById('footer-modal')!.classList.add('hidden');
@@ -1904,9 +1990,9 @@ async function _executeFooter() {
   if (!activeTab) return;
   document.getElementById('footer-modal')!.classList.add('hidden');
 
-  const left     = (document.getElementById('footer-left')     as HTMLInputElement).value;
-  const center   = (document.getElementById('footer-center')   as HTMLInputElement).value;
-  const right    = (document.getElementById('footer-right')    as HTMLInputElement).value;
+  const left     = _resolveFooterColForEmbed('left');
+  const center   = _resolveFooterColForEmbed('center');
+  const right    = _resolveFooterColForEmbed('right');
   const fontSize = parseFloat((document.getElementById('footer-fontsize') as HTMLInputElement).value) || 10;
 
   if (!left && !center && !right) return;
@@ -1928,9 +2014,43 @@ async function _executeFooter() {
 
 // ── Add Watermark ───────────────────────────────────────────────
 
+function _drawWatermarkPreview() {
+  const canvas = document.getElementById('watermark-preview') as HTMLCanvasElement;
+  const ctx    = canvas.getContext('2d')!;
+  const W = canvas.width, H = canvas.height;
+
+  ctx.clearRect(0, 0, W, H);
+  ctx.fillStyle = '#1e1e1e';
+  ctx.fillRect(0, 0, W, H);
+
+  // Page outline
+  const mx = 8, my = 8, pw = W - mx * 2, ph = H - my * 2;
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(mx, my, pw, ph);
+
+  const text     = (document.getElementById('watermark-text')     as HTMLInputElement).value.trim() || 'Preview';
+  const pdfSize  = parseFloat((document.getElementById('watermark-fontsize') as HTMLInputElement).value) || 72;
+  const opacity  = parseFloat((document.getElementById('watermark-opacity')  as HTMLInputElement).value) / 100;
+  const angle    = parseFloat((document.getElementById('watermark-angle')    as HTMLInputElement).value) || 0;
+
+  const canvasFs = Math.max(6, Math.round(pdfSize * pw / 612));
+
+  ctx.save();
+  ctx.globalAlpha  = opacity;
+  ctx.fillStyle    = '#808080';
+  ctx.font         = `bold ${canvasFs}px Helvetica, Arial, sans-serif`;
+  ctx.textAlign    = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.translate(mx + pw / 2, my + ph / 2);
+  ctx.rotate(-angle * Math.PI / 180); // negative to match pdf-lib CCW convention
+  ctx.fillText(text, 0, 0);
+  ctx.restore();
+}
+
 document.getElementById('btn-watermark')!.addEventListener('click', () => {
   if (!activeTab) return;
   document.getElementById('watermark-modal')!.classList.remove('hidden');
+  _drawWatermarkPreview();
 });
 document.getElementById('watermark-cancel')!.addEventListener('click', () => {
   document.getElementById('watermark-modal')!.classList.add('hidden');
@@ -1939,7 +2059,14 @@ document.getElementById('watermark-ok')!.addEventListener('click', _executeWater
 
 const _wmOpacityInput = document.getElementById('watermark-opacity') as HTMLInputElement;
 const _wmOpacityVal   = document.getElementById('watermark-opacity-val')!;
-_wmOpacityInput.addEventListener('input', () => { _wmOpacityVal.textContent = _wmOpacityInput.value + '%'; });
+_wmOpacityInput.addEventListener('input', () => {
+  _wmOpacityVal.textContent = _wmOpacityInput.value + '%';
+  _drawWatermarkPreview();
+});
+(document.getElementById('watermark-text')     as HTMLInputElement).addEventListener('input',  _drawWatermarkPreview);
+(document.getElementById('watermark-fontsize') as HTMLInputElement).addEventListener('input',  _drawWatermarkPreview);
+(document.getElementById('watermark-angle')    as HTMLInputElement).addEventListener('input',  _drawWatermarkPreview);
+(document.getElementById('watermark-angle')    as HTMLInputElement).addEventListener('change', _drawWatermarkPreview);
 
 async function _executeWatermark() {
   if (!activeTab) return;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1412,6 +1412,7 @@ const _menuActions = {
   'open':        () => openFile(),
   'save':        () => saveTab(activeTab),
   'save-copy':   () => saveTabCopy(activeTab),
+  'print':       () => printTab(activeTab),
   'close-tab':   () => { if (activeTab) requestCloseTab(activeTab); },
   'reopen-tab':  () => reopenLastTab(),
   'quit':        () => window.close(),

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1468,6 +1468,7 @@ window.api.onMenuEvent((event) => {
     case 'menu-open':         openFile(); break;
     case 'menu-save':         saveTab(activeTab); break;
     case 'menu-save-copy':    saveTabCopy(activeTab); break;
+    case 'menu-print':        printTab(activeTab); break;
     case 'menu-close-tab':    if (activeTab) requestCloseTab(activeTab); break;
     case 'menu-reopen-tab':   reopenLastTab(); break;
     case 'menu-extension-id': _openExtensionIdModal(); break;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -329,7 +329,7 @@ tabContextMenu.addEventListener('mousedown', (e) => {
     case 'close':        requestCloseTab(tab); break;
     case 'save':         saveTab(tab); break;
     case 'save-as':      saveTabCopy(tab); break;
-    case 'print':        switchTab(tab); window.print(); break;
+    case 'print':        switchTab(tab); printTab(tab); break;
     case 'copy-file':    window.api.copyFileToClipboard(tab.filePath!); break;
     case 'reveal':       window.api.revealInExplorer(tab.filePath!); break;
     case 'close-others':
@@ -993,6 +993,15 @@ async function saveTabCopy(tab: Tab | null) {
   return false;
 }
 
+async function printTab(tab: Tab | null) {
+  if (!tab) return;
+  if (!tab.filePath) {
+    await window.api.showMessageBox({ type: 'info', message: 'Save the document before printing.', buttons: ['OK'] });
+    return;
+  }
+  await window.api.printPdf(tab.filePath);
+}
+
 async function reopenLastTab() {
   if (_closedTabStack.length === 0) return;
   const { filePath } = _closedTabStack.pop()!;
@@ -1312,52 +1321,7 @@ document.getElementById('btn-redo')!.addEventListener('click',   () => activeTab
 document.getElementById('btn-fit')!.addEventListener('click',    fitWidth);
 document.getElementById('btn-fit-h')!.addEventListener('click',  fitHeight);
 document.getElementById('btn-rotate')!.addEventListener('click', (e) => rotate(e.shiftKey));
-document.getElementById('btn-print')!.addEventListener('click',  () => window.print());
-
-// ── TEMPORARY PRINT DEBUG ──────────────────────────────────────
-{
-  const dbgEl = document.createElement('div');
-  dbgEl.id = 'print-debug-overlay';
-  dbgEl.style.cssText = 'display:none;position:fixed;top:0;left:0;background:yellow;color:black;font:12px monospace;padding:8px;z-index:9999;white-space:pre;';
-  document.body.appendChild(dbgEl);
-
-  window.addEventListener('beforeprint', () => {
-    const lines: string[] = [];
-    lines.push(`window inner: ${window.innerWidth}x${window.innerHeight}`);
-    lines.push(`devicePixelRatio: ${window.devicePixelRatio}`);
-
-    const wrappers = document.querySelectorAll<HTMLElement>('.page-wrapper');
-    lines.push(`page-wrapper count: ${wrappers.length}`);
-
-    wrappers.forEach((wrapper, i) => {
-      const cs = getComputedStyle(wrapper);
-      lines.push(`\nwrapper[${i}]:`);
-      lines.push(`  inline style: w=${wrapper.style.width} h=${wrapper.style.height}`);
-      lines.push(`  computed:     w=${cs.width} h=${cs.height}`);
-      lines.push(`  opacity: inline=${wrapper.style.opacity} computed=${cs.opacity}`);
-
-      wrapper.querySelectorAll<HTMLCanvasElement>('canvas').forEach((c, j) => {
-        const cc = getComputedStyle(c);
-        let hasContent = false;
-        try {
-          const px = c.getContext('2d')?.getImageData(c.width >> 1, c.height >> 1, 1, 1).data;
-          hasContent = !!px && px[3] > 0;
-        } catch { /* tainted or no context */ }
-        lines.push(`  canvas[${j}] .${c.className}: attr=${c.width}x${c.height} computed=${cc.width}x${cc.height} hasContent=${hasContent}`);
-      });
-    });
-
-    const text = lines.join('\n');
-    console.log('[PRINT DEBUG]\n' + text);
-    dbgEl.textContent = text;
-    dbgEl.style.display = 'block';
-  });
-
-  window.addEventListener('afterprint', () => {
-    dbgEl.style.display = 'none';
-  });
-}
-// ── END PRINT DEBUG ────────────────────────────────────────────
+document.getElementById('btn-print')!.addEventListener('click',  () => printTab(activeTab));
 
 btnBold.addEventListener('click', () => {
   if (!activeTab?.annotator) return;
@@ -1421,7 +1385,7 @@ document.addEventListener('keydown', async (e) => {
       e.preventDefault(); ann.copy(); return;
     }
   }
-  if (ctrl && e.key === 'p') { e.preventDefault(); window.print(); return; }
+  if (ctrl && e.key === 'p') { e.preventDefault(); printTab(activeTab); return; }
   if (ctrl && e.key === 'r') { e.preventDefault(); if (activeTab) _applyZoomNow(activeTab.viewer.scale); return; }
   if (ctrl && e.key === 'f') { e.preventDefault(); finder.open(); return; }
 

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -999,7 +999,7 @@ async function printTab(tab: Tab | null) {
     await window.api.showMessageBox({ type: 'info', message: 'Save the document before printing.', buttons: ['OK'] });
     return;
   }
-  await window.api.printPdf(tab.filePath);
+  await window.api.openPrintPreview(tab.filePath);
 }
 
 async function reopenLastTab() {

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -999,6 +999,19 @@ async function printTab(tab: Tab | null) {
     await window.api.showMessageBox({ type: 'info', message: 'Save the document before printing.', buttons: ['OK'] });
     return;
   }
+  if (tab.dirty) {
+    const choice = await window.api.showMessageBox({
+      type: 'question',
+      message: 'Save before printing?',
+      detail: 'The document has unsaved annotations. Save now so they appear in the printed output.',
+      buttons: ['Save and Print', 'Cancel'],
+      defaultId: 0,
+      cancelId: 1,
+    });
+    if (choice !== 0) return;
+    await saveTab(tab);
+    if (tab.dirty) return; // save was cancelled or failed
+  }
   await window.api.openPrintPreview(tab.filePath);
 }
 

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1043,17 +1043,26 @@ function showDialog(options: {
     const footer = document.createElement('div');
     footer.className = 'modal-footer';
 
+    const controller = new AbortController();
+
     const dismiss = (idx: number) => {
-      document.removeEventListener('keydown', onKey);
-      document.body.removeChild(overlay);
+      controller.abort(); // removes the keydown listener
+      overlay.remove();
       resolve(idx);
     };
+
+    // Also clean up if the overlay is removed from the DOM by any other means
+    // (e.g. another piece of code clearing the body or closing the panel).
+    const observer = new MutationObserver(() => {
+      if (!overlay.isConnected) { controller.abort(); observer.disconnect(); resolve(cancelId); }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
 
     options.buttons.forEach((label, i) => {
       const btn = document.createElement('button');
       btn.className = 'modal-btn' + (i === defaultId ? ' primary' : '');
       btn.textContent = label;
-      btn.addEventListener('click', () => dismiss(i));
+      btn.addEventListener('click', () => { observer.disconnect(); dismiss(i); });
       footer.appendChild(btn);
     });
 
@@ -1061,8 +1070,8 @@ function showDialog(options: {
     overlay.appendChild(box);
     document.body.appendChild(overlay);
 
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') dismiss(cancelId); };
-    document.addEventListener('keydown', onKey);
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') { observer.disconnect(); dismiss(cancelId); } };
+    document.addEventListener('keydown', onKey, { signal: controller.signal });
   });
 }
 

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1121,7 +1121,31 @@ function _patchAnnotatorForDirty(tab: Tab) {
 // ── Unified undo / redo ────────────────────────────────────────
 
 const UNDO_LIMIT = 20;
+// Maximum total bytes held by unique PDF snapshots across the undo stack.
+// Consecutive annotation-only entries share the same Uint8Array reference and
+// are counted only once, so annotation edits on large files remain cheap.
+const MAX_UNDO_BYTES = 200 * 1024 * 1024; // 200 MB
 let _undoing = false;
+
+function _undoStackBytes(stack: Array<{ pdfBytes: Uint8Array; annotations: string }>): number {
+  const seen = new Set<Uint8Array>();
+  let total = 0;
+  for (const entry of stack) {
+    if (!seen.has(entry.pdfBytes)) {
+      seen.add(entry.pdfBytes);
+      total += entry.pdfBytes.byteLength;
+    }
+  }
+  return total;
+}
+
+function _shiftOldestUndo(tab: Tab): void {
+  tab._undoStack!.shift();
+  if (tab._undoCleanIdx != null) {
+    tab._undoCleanIdx--;
+    if (tab._undoCleanIdx < 0) tab._undoCleanIdx = null; // clean entry was dropped
+  }
+}
 
 function _pushUndo(tab: Tab): void {
   if (_undoing) return;
@@ -1134,13 +1158,11 @@ function _pushUndo(tab: Tab): void {
     tab._undoStack.splice(nextIdx);
   }
   tab._undoStack.push({ pdfBytes: tab.pdfBytes, annotations });
-  // Enforce limit. If the oldest entry is dropped, shift the clean index down with it.
-  if (tab._undoStack.length > UNDO_LIMIT) {
-    tab._undoStack.shift();
-    if (tab._undoCleanIdx != null) {
-      tab._undoCleanIdx--;
-      if (tab._undoCleanIdx < 0) tab._undoCleanIdx = null; // clean entry was dropped
-    }
+  // Enforce count limit.
+  if (tab._undoStack.length > UNDO_LIMIT) _shiftOldestUndo(tab);
+  // Enforce byte budget: drop oldest entries (never below 1) until under budget.
+  while (tab._undoStack.length > 1 && _undoStackBytes(tab._undoStack) > MAX_UNDO_BYTES) {
+    _shiftOldestUndo(tab);
   }
   tab._undoIdx = tab._undoStack.length - 1;
 }

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -993,20 +993,77 @@ async function saveTabCopy(tab: Tab | null) {
   return false;
 }
 
+// ── Generic custom dialog ──────────────────────────────────────
+// Builds a modal matching the app's existing style and resolves with
+// the index of the button the user clicked (Escape resolves cancelId).
+function showDialog(options: {
+  title:     string;
+  message:   string;
+  buttons:   string[];
+  defaultId?: number;
+  cancelId?:  number;
+}): Promise<number> {
+  return new Promise(resolve => {
+    const cancelId  = options.cancelId  ?? options.buttons.length - 1;
+    const defaultId = options.defaultId ?? 0;
+
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+
+    const box = document.createElement('div');
+    box.className = 'modal-box';
+    box.style.minWidth = '340px';
+
+    const titleEl = document.createElement('div');
+    titleEl.className = 'modal-title';
+    titleEl.textContent = options.title;
+    box.appendChild(titleEl);
+
+    const msgEl = document.createElement('p');
+    msgEl.className = 'modal-hint';
+    msgEl.textContent = options.message;
+    box.appendChild(msgEl);
+
+    const footer = document.createElement('div');
+    footer.className = 'modal-footer';
+
+    const dismiss = (idx: number) => {
+      document.removeEventListener('keydown', onKey);
+      document.body.removeChild(overlay);
+      resolve(idx);
+    };
+
+    options.buttons.forEach((label, i) => {
+      const btn = document.createElement('button');
+      btn.className = 'modal-btn' + (i === defaultId ? ' primary' : '');
+      btn.textContent = label;
+      btn.addEventListener('click', () => dismiss(i));
+      footer.appendChild(btn);
+    });
+
+    box.appendChild(footer);
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') dismiss(cancelId); };
+    document.addEventListener('keydown', onKey);
+  });
+}
+
 async function printTab(tab: Tab | null) {
   if (!tab) return;
   if (!tab.filePath) {
-    await window.api.showMessageBox({ type: 'info', message: 'Save the document before printing.', buttons: ['OK'] });
+    await showDialog({ title: 'Print', message: 'Save the document before printing.', buttons: ['OK'], defaultId: 0, cancelId: 0 });
     return;
   }
   if (tab.dirty) {
-    const choice = await window.api.showMessageBox({
-      type: 'question',
-      message: 'Save before printing?',
-      detail: 'The document has unsaved annotations. Save now so they appear in the printed output.',
-      buttons: ['Save and Print', 'Cancel'],
+    const name   = tab.filePath.replace(/.*[\\/]/, '');
+    const choice = await showDialog({
+      title:     'Unsaved Changes',
+      message:   `"${name}" has unsaved annotations. Save now so they appear in the printed output.`,
+      buttons:   ['Save and Print', 'Cancel'],
       defaultId: 0,
-      cancelId: 1,
+      cancelId:  1,
     });
     if (choice !== 0) return;
     await saveTab(tab);
@@ -1623,13 +1680,12 @@ async function _executeCombine() {
       const name    = tab.filePath ? tab.filePath.replace(/.*[\\/]/, '') : 'Untitled';
       const hasPath = tab.filePath && /[\\/]/.test(tab.filePath);
       const buttons = ['Discard changes', ...(hasPath ? ['Save'] : []), 'Save As\u2026', 'Cancel'];
-      const choice  = await window.api.showMessageBox({
-        type:      'question',
+      const saveIdx = buttons.includes('Save') ? buttons.indexOf('Save') : buttons.indexOf('Save As\u2026');
+      const choice  = await showDialog({
         title:     'Unsaved Changes',
-        message:   `\u201c${name}\u201d has unsaved annotations.`,
-        detail:    'Choose how to handle them before combining.',
+        message:   `\u201c${name}\u201d has unsaved annotations. Choose how to handle them before combining.`,
         buttons,
-        defaultId: 0,
+        defaultId: saveIdx,
         cancelId:  buttons.indexOf('Cancel'),
       });
       const action = buttons[choice];

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1125,7 +1125,7 @@ const UNDO_LIMIT = 20;
 // Consecutive annotation-only entries share the same Uint8Array reference and
 // are counted only once, so annotation edits on large files remain cheap.
 const MAX_UNDO_BYTES = 200 * 1024 * 1024; // 200 MB
-let _undoing = false;
+const _undoing = new Set<number>(); // tab IDs currently in flight for undo/redo
 
 function _undoStackBytes(stack: Array<{ pdfBytes: Uint8Array; annotations: string }>): number {
   const seen = new Set<Uint8Array>();
@@ -1148,7 +1148,7 @@ function _shiftOldestUndo(tab: Tab): void {
 }
 
 function _pushUndo(tab: Tab): void {
-  if (_undoing) return;
+  if (_undoing.has(tab.id)) return;
   const annotations = tab.annotator ? JSON.stringify(tab.annotator.annotations) : '[]';
   if (!tab._undoStack) { tab._undoStack = []; tab._undoIdx = -1; }
   // Truncate forward history. If the clean state is in the discarded future, mark it unreachable.
@@ -1485,23 +1485,23 @@ document.querySelectorAll('.swatch').forEach(s => {
 });
 
 document.getElementById('btn-undo')!.addEventListener('click', async () => {
-  if (_undoing) return;
   const tab = activeTab;
-  if (!tab?._undoStack || (tab._undoIdx ?? -1) <= 0) return;
+  if (!tab || _undoing.has(tab.id)) return;
+  if (!tab._undoStack || (tab._undoIdx ?? -1) <= 0) return;
   const idx = tab._undoIdx!;
   tab._undoIdx = idx - 1;
-  _undoing = true;
-  try { await _applyUndo(tab, tab._undoStack[idx - 1]); } finally { _undoing = false; }
+  _undoing.add(tab.id);
+  try { await _applyUndo(tab, tab._undoStack[idx - 1]); } finally { _undoing.delete(tab.id); }
 });
 document.getElementById('btn-redo')!.addEventListener('click', async () => {
-  if (_undoing) return;
   const tab = activeTab;
-  if (!tab?._undoStack) return;
+  if (!tab || _undoing.has(tab.id)) return;
+  if (!tab._undoStack) return;
   const idx = tab._undoIdx ?? -1;
   if (idx >= tab._undoStack.length - 1) return;
   tab._undoIdx = idx + 1;
-  _undoing = true;
-  try { await _applyUndo(tab, tab._undoStack[idx + 1]); } finally { _undoing = false; }
+  _undoing.add(tab.id);
+  try { await _applyUndo(tab, tab._undoStack[idx + 1]); } finally { _undoing.delete(tab.id); }
 });
 document.getElementById('btn-fit')!.addEventListener('click',    fitWidth);
 document.getElementById('btn-fit-h')!.addEventListener('click',  fitHeight);
@@ -1562,25 +1562,25 @@ document.addEventListener('keydown', async (e) => {
 
   if (ctrl && e.key === 'z') {
     e.preventDefault();
-    if (_undoing) return;
     const tab = activeTab;
-    if (!tab?._undoStack || (tab._undoIdx ?? -1) <= 0) return;
+    if (!tab || _undoing.has(tab.id)) return;
+    if (!tab._undoStack || (tab._undoIdx ?? -1) <= 0) return;
     const idx = tab._undoIdx!;
     tab._undoIdx = idx - 1;
-    _undoing = true;
-    try { await _applyUndo(tab, tab._undoStack[idx - 1]); } finally { _undoing = false; }
+    _undoing.add(tab.id);
+    try { await _applyUndo(tab, tab._undoStack[idx - 1]); } finally { _undoing.delete(tab.id); }
     return;
   }
   if (ctrl && (e.key === 'y' || (e.shiftKey && e.key === 'Z'))) {
     e.preventDefault();
-    if (_undoing) return;
     const tab = activeTab;
-    if (!tab?._undoStack) return;
+    if (!tab || _undoing.has(tab.id)) return;
+    if (!tab._undoStack) return;
     const idx = tab._undoIdx ?? -1;
     if (idx >= tab._undoStack.length - 1) return;
     tab._undoIdx = idx + 1;
-    _undoing = true;
-    try { await _applyUndo(tab, tab._undoStack[idx + 1]); } finally { _undoing = false; }
+    _undoing.add(tab.id);
+    try { await _applyUndo(tab, tab._undoStack[idx + 1]); } finally { _undoing.delete(tab.id); }
     return;
   }
   if (ctrl && e.key === 'x') { e.preventDefault(); activeTab?.annotator?.cut(); return; }

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -10,7 +10,7 @@ import type * as PDFLibNS from 'pdf-lib';
 import type { OutlineNode } from './types.js';
 const { PDFDocument } = _pdfLib as unknown as typeof PDFLibNS;
 import { FindBar }          from './find.js';
-import type { Tab, CloseContext } from './types.js';
+import type { Tab, CloseContext, Annotation } from './types.js';
 
 // ── State ──────────────────────────────────────────────────────
 
@@ -844,6 +844,7 @@ async function _loadTabContent(tab: Tab) {
     await tab.viewer.load(tab.pdfBytes);
     tab.annotator = new Annotator(tab.viewer.pages, tab.viewer);
     _patchAnnotatorForDirty(tab);
+    _pushUndo(tab);
     tab.outline = await tab.viewer.getOutline();
   } catch (err) {
     const name = tab.filePath ? tab.filePath.split(/[\\/]/).pop() : 'file';
@@ -1109,6 +1110,46 @@ function _patchAnnotatorForDirty(tab: Tab) {
     },
   });
   tab.annotator!.annotations = proxy;
+  tab.annotator!.onCommit = () => _pushUndo(tab);
+}
+
+// ── Unified undo / redo ────────────────────────────────────────
+
+const UNDO_LIMIT = 20;
+let _undoing = false;
+
+function _pushUndo(tab: Tab): void {
+  if (_undoing) return;
+  const annotations = tab.annotator ? JSON.stringify(tab.annotator.annotations) : '[]';
+  if (!tab._undoStack) { tab._undoStack = []; tab._undoIdx = -1; }
+  tab._undoStack.splice(tab._undoIdx! + 1);
+  tab._undoStack.push({ pdfBytes: tab.pdfBytes, annotations });
+  if (tab._undoStack.length > UNDO_LIMIT) tab._undoStack.shift();
+  tab._undoIdx = tab._undoStack.length - 1;
+}
+
+async function _applyUndo(tab: Tab, entry: { pdfBytes: Uint8Array; annotations: string }): Promise<void> {
+  const prevBytes = tab.pdfBytes;
+  tab.pdfBytes = entry.pdfBytes;
+  if (entry.pdfBytes !== prevBytes) {
+    const scrollTop = tab.pane.scrollTop;
+    const reloadEl = document.createElement('div');
+    reloadEl.className = 'loading-overlay';
+    reloadEl.innerHTML = '<div class="spinner"></div>';
+    tab.pane.appendChild(reloadEl);
+    tab.loadingEl = reloadEl;
+    finder.invalidateTab(tab);
+    await _loadTabContent(tab);
+    const data = JSON.parse(entry.annotations) as Annotation[];
+    if (data.length > 0) {
+      tab.annotator!.annotations.splice(0, tab.annotator!.annotations.length, ...data);
+      tab.annotator!.redrawAll();
+    }
+    requestAnimationFrame(() => { tab.pane.scrollTop = scrollTop; });
+  } else {
+    tab.annotator?.setAnnotations(entry.annotations);
+  }
+  markDirty(tab);
 }
 
 // ── Zoom ───────────────────────────────────────────────────────
@@ -1395,8 +1436,25 @@ document.querySelectorAll('.swatch').forEach(s => {
   });
 });
 
-document.getElementById('btn-undo')!.addEventListener('click',   () => activeTab?.annotator?.undo());
-document.getElementById('btn-redo')!.addEventListener('click',   () => activeTab?.annotator?.redo());
+document.getElementById('btn-undo')!.addEventListener('click', async () => {
+  if (_undoing) return;
+  const tab = activeTab;
+  if (!tab?._undoStack || (tab._undoIdx ?? -1) <= 0) return;
+  const idx = tab._undoIdx!;
+  tab._undoIdx = idx - 1;
+  _undoing = true;
+  try { await _applyUndo(tab, tab._undoStack[idx - 1]); } finally { _undoing = false; }
+});
+document.getElementById('btn-redo')!.addEventListener('click', async () => {
+  if (_undoing) return;
+  const tab = activeTab;
+  if (!tab?._undoStack) return;
+  const idx = tab._undoIdx ?? -1;
+  if (idx >= tab._undoStack.length - 1) return;
+  tab._undoIdx = idx + 1;
+  _undoing = true;
+  try { await _applyUndo(tab, tab._undoStack[idx + 1]); } finally { _undoing = false; }
+});
 document.getElementById('btn-fit')!.addEventListener('click',    fitWidth);
 document.getElementById('btn-fit-h')!.addEventListener('click',  fitHeight);
 document.getElementById('btn-rotate')!.addEventListener('click', (e) => rotate(e.shiftKey));
@@ -1454,8 +1512,29 @@ document.addEventListener('keydown', async (e) => {
   if (ctrl && e.key === '0') { e.preventDefault(); fitWidth(); return; }
   if (document.activeElement?.tagName === 'INPUT' || document.activeElement?.tagName === 'TEXTAREA') return;
 
-  if (ctrl && e.key === 'z') { e.preventDefault(); activeTab?.annotator?.undo(); return; }
-  if (ctrl && (e.key === 'y' || (e.shiftKey && e.key === 'Z'))) { e.preventDefault(); activeTab?.annotator?.redo(); return; }
+  if (ctrl && e.key === 'z') {
+    e.preventDefault();
+    if (_undoing) return;
+    const tab = activeTab;
+    if (!tab?._undoStack || (tab._undoIdx ?? -1) <= 0) return;
+    const idx = tab._undoIdx!;
+    tab._undoIdx = idx - 1;
+    _undoing = true;
+    try { await _applyUndo(tab, tab._undoStack[idx - 1]); } finally { _undoing = false; }
+    return;
+  }
+  if (ctrl && (e.key === 'y' || (e.shiftKey && e.key === 'Z'))) {
+    e.preventDefault();
+    if (_undoing) return;
+    const tab = activeTab;
+    if (!tab?._undoStack) return;
+    const idx = tab._undoIdx ?? -1;
+    if (idx >= tab._undoStack.length - 1) return;
+    tab._undoIdx = idx + 1;
+    _undoing = true;
+    try { await _applyUndo(tab, tab._undoStack[idx + 1]); } finally { _undoing = false; }
+    return;
+  }
   if (ctrl && e.key === 'x') { e.preventDefault(); activeTab?.annotator?.cut(); return; }
   if (ctrl && e.key === 'v') { e.preventDefault(); activeTab?.annotator?.paste(); return; }
   if (ctrl && e.key === 'c') {
@@ -1876,6 +1955,7 @@ async function _executeReorder() {
   pages.forEach(p => resultDoc.addPage(p));
   const bytes = await resultDoc.save();
 
+  _pushUndo(tab);
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   // Re-add loading overlay for the re-render
@@ -2000,6 +2080,7 @@ async function _executeFooter() {
   const tab   = activeTab;
   const bytes = await embedFooter(tab.pdfBytes, { left, center, right, fontSize });
 
+  _pushUndo(tab);
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   const reloadEl = document.createElement('div');
@@ -2089,6 +2170,7 @@ async function _executeWatermark() {
   const tab   = activeTab;
   const bytes = await embedWatermark(tab.pdfBytes, { text, fontSize, opacity, angle });
 
+  _pushUndo(tab);
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   const reloadEl = document.createElement('div');

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -33,6 +33,7 @@ const _closedTabStack: { filePath: string }[] = [];
 let _zoomTimer: ReturnType<typeof setTimeout> | null = null; // setTimeout handle for deferred re-render
 let _zoomTarget: number | null = null; // accumulated target scale while debounce is pending
 let _zoomCursor: { x: number; y: number } | null = null; // cursor pane-relative coords at zoom start
+let _zoomTabId:  number | null = null;  // ID of the tab that started the current zoom gesture
 
 // Custom scrollbar drag state
 let _sbDragging        = false;
@@ -1224,6 +1225,7 @@ function zoom(delta: number, cursorX?: number, cursorY?: number) {
         x: Math.max(0, Math.min(pane.clientWidth,  cursorX - paneRect.left)),
         y: Math.max(0, Math.min(pane.clientHeight, cursorY - paneRect.top)),
       };
+      _zoomTabId = activeTab.id;
     }
 
     if (_zoomCursor !== null) {
@@ -1259,8 +1261,10 @@ async function _applyZoomNow(scale: number) {
   const v        = activeTab.viewer;
   const pane     = activeTab.pane;
   const oldScale = v.scale;
-  const cursor   = _zoomCursor;
+  // Discard stale cursor if the user switched tabs during the debounce.
+  const cursor   = (activeTab.id === _zoomTabId) ? _zoomCursor : null;
   _zoomCursor    = null;
+  _zoomTabId     = null;
 
   // Capture scroll snapshot before the CSS transform is removed so the
   // pre-scroll and final-scroll calculations both use the committed position.

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -3,7 +3,7 @@
 
 import { PDFViewer }        from './viewer.js';
 import { Annotator }        from './annotator.js';
-import { embedAnnotations } from './saver.js';
+import { embedAnnotations, embedFooter, embedWatermark } from './saver.js';
 // @ts-expect-error — pdf-lib is imported via direct path for Electron's file:// ESM loader
 import * as _pdfLib       from '../../node_modules/pdf-lib/dist/pdf-lib.esm.js';
 import type * as PDFLibNS from 'pdf-lib';
@@ -1798,7 +1798,11 @@ async function _openReorderModal() {
     btnR.className = 'reorder-arrow';
     btnR.title     = 'Move right';
     btnR.innerHTML = '&#8594;';
-    controls.append(btnL, btnR);
+    const btnDel = document.createElement('button');
+    btnDel.className = 'reorder-arrow reorder-remove';
+    btnDel.title     = 'Remove page';
+    btnDel.innerHTML = '&#x2715;';
+    controls.append(btnL, btnR, btnDel);
 
     thumb.append(img, num, controls);
 
@@ -1810,6 +1814,13 @@ async function _openReorderModal() {
 
     btnL.addEventListener('click', (e) => { e.stopPropagation(); selectThumb(thumb); moveThumb(thumb, -1); });
     btnR.addEventListener('click', (e) => { e.stopPropagation(); selectThumb(thumb); moveThumb(thumb,  1); });
+    btnDel.addEventListener('click', (e) => {
+      e.stopPropagation();
+      thumb.remove();
+      container.querySelectorAll('.reorder-page-num').forEach((s, i) => {
+        s.textContent = `Page ${i + 1}`;
+      });
+    });
 
     thumb.addEventListener('dragstart', (e) => {
       e.dataTransfer!.setData('reorder-orig', String(thumb.dataset.orig));
@@ -1851,11 +1862,14 @@ async function _executeReorder() {
   if (!activeTab) return;
   document.getElementById('reorder-modal')!.classList.add('hidden');
 
+  const tab       = activeTab;
   const container = document.getElementById('reorder-pages')!;
   const newOrder  = [...container.querySelectorAll('.reorder-thumb')].map(el => Number((el as HTMLElement).dataset.orig));
-  if (newOrder.every((v, i) => v === i)) return; // unchanged
-
-  const tab = activeTab;
+  if (newOrder.length === 0) {
+    await showDialog({ title: 'Remove Pages', message: 'Cannot remove all pages.', buttons: ['OK'], defaultId: 0, cancelId: 0 });
+    return;
+  }
+  if (newOrder.length === tab.viewer.pageCount && newOrder.every((v, i) => v === i)) return; // unchanged
   const srcDoc    = await PDFDocument.load(tab.pdfBytes, { ignoreEncryption: true });
   const resultDoc = await PDFDocument.create();
   const pages     = await resultDoc.copyPages(srcDoc, newOrder);
@@ -1865,6 +1879,84 @@ async function _executeReorder() {
   tab.pdfBytes = bytes;
   tab.annotator!.clear();
   // Re-add loading overlay for the re-render
+  const reloadEl = document.createElement('div');
+  reloadEl.className = 'loading-overlay';
+  reloadEl.innerHTML = '<div class="spinner"></div>';
+  tab.pane.appendChild(reloadEl);
+  tab.loadingEl = reloadEl;
+  finder.invalidateTab(tab);
+  await _loadTabContent(tab);
+  markDirty(tab);
+}
+
+// ── Add Footer ─────────────────────────────────────────────────
+
+document.getElementById('btn-footer')!.addEventListener('click', () => {
+  if (!activeTab) return;
+  document.getElementById('footer-modal')!.classList.remove('hidden');
+});
+document.getElementById('footer-cancel')!.addEventListener('click', () => {
+  document.getElementById('footer-modal')!.classList.add('hidden');
+});
+document.getElementById('footer-ok')!.addEventListener('click', _executeFooter);
+
+async function _executeFooter() {
+  if (!activeTab) return;
+  document.getElementById('footer-modal')!.classList.add('hidden');
+
+  const left     = (document.getElementById('footer-left')     as HTMLInputElement).value;
+  const center   = (document.getElementById('footer-center')   as HTMLInputElement).value;
+  const right    = (document.getElementById('footer-right')    as HTMLInputElement).value;
+  const fontSize = parseFloat((document.getElementById('footer-fontsize') as HTMLInputElement).value) || 10;
+
+  if (!left && !center && !right) return;
+
+  const tab   = activeTab;
+  const bytes = await embedFooter(tab.pdfBytes, { left, center, right, fontSize });
+
+  tab.pdfBytes = bytes;
+  tab.annotator!.clear();
+  const reloadEl = document.createElement('div');
+  reloadEl.className = 'loading-overlay';
+  reloadEl.innerHTML = '<div class="spinner"></div>';
+  tab.pane.appendChild(reloadEl);
+  tab.loadingEl = reloadEl;
+  finder.invalidateTab(tab);
+  await _loadTabContent(tab);
+  markDirty(tab);
+}
+
+// ── Add Watermark ───────────────────────────────────────────────
+
+document.getElementById('btn-watermark')!.addEventListener('click', () => {
+  if (!activeTab) return;
+  document.getElementById('watermark-modal')!.classList.remove('hidden');
+});
+document.getElementById('watermark-cancel')!.addEventListener('click', () => {
+  document.getElementById('watermark-modal')!.classList.add('hidden');
+});
+document.getElementById('watermark-ok')!.addEventListener('click', _executeWatermark);
+
+const _wmOpacityInput = document.getElementById('watermark-opacity') as HTMLInputElement;
+const _wmOpacityVal   = document.getElementById('watermark-opacity-val')!;
+_wmOpacityInput.addEventListener('input', () => { _wmOpacityVal.textContent = _wmOpacityInput.value + '%'; });
+
+async function _executeWatermark() {
+  if (!activeTab) return;
+  document.getElementById('watermark-modal')!.classList.add('hidden');
+
+  const text     = (document.getElementById('watermark-text')     as HTMLInputElement).value.trim();
+  const fontSize = parseFloat((document.getElementById('watermark-fontsize') as HTMLInputElement).value) || 72;
+  const opacity  = parseFloat((document.getElementById('watermark-opacity')  as HTMLInputElement).value) / 100;
+  const angle    = parseFloat((document.getElementById('watermark-angle')    as HTMLInputElement).value) || 0;
+
+  if (!text) return;
+
+  const tab   = activeTab;
+  const bytes = await embedWatermark(tab.pdfBytes, { text, fontSize, opacity, angle });
+
+  tab.pdfBytes = bytes;
+  tab.annotator!.clear();
   const reloadEl = document.createElement('div');
   reloadEl.className = 'loading-overlay';
   reloadEl.innerHTML = '<div class="spinner"></div>';

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1095,8 +1095,10 @@ async function fitHeight() {
 async function rotate(singlePage: boolean) {
   if (!activeTab) return;
   const v = activeTab.viewer;
+  const targetPage = singlePage ? v.getVisiblePageNum() : null;
   if (singlePage) await v.rotatePage(v.getVisiblePageNum(), 90);
   else            await v.rotateAll(90);
+  activeTab.annotator!.rotateAnnotations(targetPage, 90);
   activeTab.annotator!.pages = v.pages;
   activeTab.annotator!.redrawAll();
   activeTab.annotator!.setTool(activeTab.annotator!.tool);

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -32,6 +32,7 @@ const _closedTabStack: { filePath: string }[] = [];
 // Zoom debounce state
 let _zoomTimer: ReturnType<typeof setTimeout> | null = null; // setTimeout handle for deferred re-render
 let _zoomTarget: number | null = null; // accumulated target scale while debounce is pending
+let _zoomCursor: { x: number; y: number } | null = null; // cursor pane-relative coords at zoom start
 
 // Custom scrollbar drag state
 let _sbDragging        = false;
@@ -1026,7 +1027,7 @@ function _patchAnnotatorForDirty(tab: Tab) {
 
 // Immediately apply a CSS scale transform to the page container for visual
 // feedback, then re-render at the true scale after a 250 ms debounce.
-function zoom(delta: number) {
+function zoom(delta: number, cursorX?: number, cursorY?: number) {
   if (!activeTab) return;
   const v        = activeTab.viewer;
   const newScale = Math.max(0.25, Math.min(5,
@@ -1037,8 +1038,27 @@ function zoom(delta: number) {
   const pagesEl = activeTab.pane.querySelector('.pdf-pages') as HTMLElement | null;
   if (pagesEl) {
     const ratio = newScale / v.scale;
-    pagesEl.style.transformOrigin = 'top center';
-    pagesEl.style.transform       = `scale(${ratio})`;
+
+    // Capture cursor position once per gesture (don't overwrite if debounce is already running)
+    if (cursorX !== undefined && cursorY !== undefined && _zoomCursor === null) {
+      const pane     = activeTab.pane;
+      const paneRect = pane.getBoundingClientRect();
+      _zoomCursor = {
+        x: Math.max(0, Math.min(pane.clientWidth,  cursorX - paneRect.left)),
+        y: Math.max(0, Math.min(pane.clientHeight, cursorY - paneRect.top)),
+      };
+    }
+
+    if (_zoomCursor !== null) {
+      const pane    = activeTab.pane;
+      const originX = pane.scrollLeft + _zoomCursor.x - pagesEl.offsetLeft;
+      const originY = pane.scrollTop  + _zoomCursor.y - pagesEl.offsetTop;
+      pagesEl.style.transformOrigin = `${originX}px ${originY}px`;
+    } else {
+      pagesEl.style.transformOrigin = 'top center';
+    }
+
+    pagesEl.style.transform = `scale(${ratio})`;
   }
 
   // Debounce: wait until the user stops zooming, then do the real re-render
@@ -1062,8 +1082,20 @@ async function _applyZoomNow(scale: number) {
   const pagesEl = activeTab.pane.querySelector('.pdf-pages') as HTMLElement | null;
   if (pagesEl) pagesEl.style.transform = '';
 
-  const v = activeTab.viewer;
+  const v        = activeTab.viewer;
+  const pane     = activeTab.pane;
+  const oldScale = v.scale;
+  const cursor   = _zoomCursor;
+  _zoomCursor    = null;
+
   await v.setZoom(scale);
+
+  if (cursor !== null) {
+    const ratio     = scale / oldScale;
+    pane.scrollLeft = (pane.scrollLeft + cursor.x) * ratio - cursor.x;
+    pane.scrollTop  = (pane.scrollTop  + cursor.y) * ratio - cursor.y;
+  }
+
   activeTab.annotator!.pages = v.pages;
   activeTab.annotator!.redrawAll();
   activeTab.annotator!.setTool(activeTab.annotator!.tool);
@@ -1300,7 +1332,7 @@ pageInput.addEventListener('change', () => jumpToPage(Number(pageInput.value)));
 viewerHost.addEventListener('wheel', (e) => {
   if (!e.ctrlKey) return;
   e.preventDefault();
-  zoom(e.deltaY < 0 ? 0.1 : -0.1);
+  zoom(e.deltaY < 0 ? 0.1 : -0.1, e.clientX, e.clientY);
 }, { passive: false });
 
 // ── Keyboard shortcuts ─────────────────────────────────────────

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -41,6 +41,7 @@ let pageData: PageData[] = []; // index 0 = page 1
     const opt = document.createElement('option');
     opt.textContent = 'No printers found';
     selPrinter.appendChild(opt);
+    btnPrint.disabled = true;
     return;
   }
   printers.forEach((p: { name: string; isDefault: boolean }) => {
@@ -125,6 +126,15 @@ function buildComposite(pageSlots: number[], cols: number, targetW: number, targ
       const scale = Math.min(slotW / naturalW, slotH / naturalH);
       const dw = naturalW * scale, dh = naturalH * scale;
       ctx.drawImage(img, slotX + (slotW - dw) / 2, slotY + (slotH - dh) / 2, dw, dh);
+    } else {
+      // Blank slot — subtle fill and label so users know it's intentional
+      ctx.fillStyle = '#f0f0f0';
+      ctx.fillRect(slotX + 0.5, slotY + 0.5, slotW - 1, slotH - 1);
+      ctx.font = `${Math.round(Math.min(slotW, slotH) * 0.07)}px system-ui, sans-serif`;
+      ctx.fillStyle = '#bbb';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('Blank', slotX + slotW / 2, slotY + slotH / 2);
     }
     // Faint slot border
     ctx.strokeStyle = '#ddd';
@@ -233,43 +243,70 @@ btnPrint.addEventListener('click', async () => {
 
   btnPrint.disabled = true;
   statusEl.textContent = 'Printing…';
-  await window.api.executePrint({
-    deviceName: selPrinter.value,
-    copies,
-    color:      !grey,
-    collate:    chkCollate.checked,
-    duplexMode,
-    scaleFactor,
-    landscape,
-  });
+  try {
+    const result = await window.api.executePrint({
+      deviceName: selPrinter.value,
+      copies,
+      color:      !grey,
+      collate:    chkCollate.checked,
+      duplexMode,
+      scaleFactor,
+      landscape,
+    });
+    if (!result.ok) {
+      statusEl.textContent = `Print failed: ${result.error ?? 'unknown error'}`;
+      btnPrint.disabled = false;
+      return;
+    }
+  } catch (err) {
+    statusEl.textContent = `Print error: ${(err as Error).message}`;
+    btnPrint.disabled = false;
+    return;
+  }
   window.close();
 });
 
 // ── Receive PDF data from main ─────────────────────────────────
 window.api.onPdfData(async ({ buffer }) => {
   statusEl.textContent = 'Rendering pages…';
-  const bytes  = new Uint8Array(buffer);
-  const pdfDoc = await pdfjsLib.getDocument({ data: bytes }).promise;
-  totalPages   = pdfDoc.numPages;
 
-  for (let pageNum = 1; pageNum <= totalPages; pageNum++) {
-    const page     = await pdfDoc.getPage(pageNum);
-    const viewport = page.getViewport({ scale: 1.5 });
-    const canvas   = document.createElement('canvas');
-    canvas.width   = viewport.width;
-    canvas.height  = viewport.height;
-    await page.render({ canvasContext: canvas.getContext('2d')!, viewport }).promise;
+  let pdfDoc;
+  try {
+    const bytes = new Uint8Array(buffer);
+    pdfDoc = await pdfjsLib.getDocument({ data: bytes }).promise;
+  } catch (err) {
+    statusEl.textContent = `Failed to load PDF: ${(err as Error).message}`;
+    return;
+  }
+  totalPages = pdfDoc.numPages;
 
-    const dataUrl  = canvas.toDataURL('image/png');
-    const img      = new Image();
-    await new Promise<void>(resolve => { img.onload = () => resolve(); img.src = dataUrl; });
+  try {
+    for (let pageNum = 1; pageNum <= totalPages; pageNum++) {
+      const page     = await pdfDoc.getPage(pageNum);
+      const viewport = page.getViewport({ scale: 1.5 });
+      const canvas   = document.createElement('canvas');
+      canvas.width   = viewport.width;
+      canvas.height  = viewport.height;
+      await page.render({ canvasContext: canvas.getContext('2d')!, viewport }).promise;
 
-    pageData.push({
-      img,
-      naturalW: viewport.width  / 1.5,
-      naturalH: viewport.height / 1.5,
-    });
-    statusEl.textContent = `Rendering… ${pageNum}/${totalPages}`;
+      const dataUrl  = canvas.toDataURL('image/png');
+      const img      = new Image();
+      await new Promise<void>(resolve => {
+        img.onload  = () => resolve();
+        img.onerror = () => resolve(); // silently skip bad frames
+        img.src = dataUrl;
+      });
+
+      pageData.push({
+        img,
+        naturalW: viewport.width  / 1.5,
+        naturalH: viewport.height / 1.5,
+      });
+      statusEl.textContent = `Rendering… ${pageNum}/${totalPages}`;
+    }
+  } catch (err) {
+    statusEl.textContent = `Rendering error: ${(err as Error).message}`;
+    return;
   }
 
   statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -74,7 +74,7 @@ function parsePageRange(str: string): Set<number> | null {
       if (!isNaN(n) && n >= 1 && n <= totalPages) result.add(n);
     }
   }
-  return result.size > 0 ? result : null;
+  return result;
 }
 
 // ── Booklet ordering ──────────────────────────────────────────
@@ -239,7 +239,9 @@ btnPrint.addEventListener('click', async () => {
   const scaleVal    = selScale.value;
   const scaleFactor = (scaleVal === 'fit' || scaleVal === '100') ? 100 : parseInt(scaleVal);
   const duplexMode  = selDuplex.value as 'simplex' | 'longEdge' | 'shortEdge';
-  const landscape   = chkBooklet.checked; // booklet composites are landscape
+  // Booklet composites are always landscape; otherwise follow the first page's orientation
+  const landscape   = chkBooklet.checked ||
+    (pageData.length > 0 && pageData[0].naturalW > pageData[0].naturalH);
 
   btnPrint.disabled = true;
   statusEl.textContent = 'Printing…';

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -29,6 +29,7 @@ const zoomLabel      = document.getElementById('zoom-label')!;
 // ── State ─────────────────────────────────────────────────────
 let totalPages = 0;
 let previewZoom = 1.0;
+let printOrientation: 'portrait' | 'landscape' = 'portrait';
 
 const ZOOM_STEPS = [0.25, 0.33, 0.5, 0.67, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0];
 
@@ -172,10 +173,13 @@ function buildComposite(pageSlots: number[], cols: number, targetW: number, targ
 }
 
 // ── Add a page wrapper to the preview ────────────────────────
-function addPreviewPage(imgEl: HTMLImageElement, displayW: number, displayH: number) {
-  imgEl.style.cssText = `width:${displayW}px; height:${displayH}px;`;
+// paperW/H are the paper dimensions; imgEl scales to fit inside.
+function addPreviewPage(imgEl: HTMLImageElement, paperW: number, paperH: number) {
+  imgEl.style.cssText = '';
   const wrapper = document.createElement('div');
   wrapper.className = 'print-page';
+  wrapper.style.width  = `${paperW}px`;
+  wrapper.style.height = `${paperH}px`;
   wrapper.appendChild(imgEl);
   previewArea.appendChild(wrapper);
 }
@@ -193,14 +197,20 @@ function renderPreview() {
   const refW = pageData[0].naturalW;
   const refH = pageData[0].naturalH;
 
+  // Paper dimensions: honour orientation toggle (booklet is always landscape)
+  const shortSide = Math.min(refW, refH);
+  const longSide  = Math.max(refW, refH);
+  const paperW = (isBooklet || printOrientation === 'landscape') ? longSide : shortSide;
+  const paperH = (isBooklet || printOrientation === 'landscape') ? shortSide : longSide;
+
   if (isBooklet) {
     // Booklet: always uses all pages; composites are landscape (2× wide)
     const sheets = getBookletOrder(totalPages);
     sheets.forEach(sheet => {
       (['front', 'back'] as const).forEach(side => {
         const [lp, rp] = sheet[side];
-        const img = buildComposite([lp, rp], 2, refW * 2, refH);
-        addPreviewPage(img, refW * 2, refH);
+        const img = buildComposite([lp, rp], 2, paperW * 2, paperH);
+        addPreviewPage(img, paperW * 2, paperH);
       });
     });
   } else if (pps > 1) {
@@ -215,17 +225,17 @@ function renderPreview() {
     for (let i = 0; i < visible.length; i += pps) {
       const chunk = visible.slice(i, i + pps);
       while (chunk.length < pps) chunk.push(0); // pad with blanks
-      const img = buildComposite(chunk, cols, refW, refH);
-      addPreviewPage(img, refW, refH);
+      const img = buildComposite(chunk, cols, paperW, paperH);
+      addPreviewPage(img, paperW, paperH);
     }
   } else {
-    // Single page per sheet
+    // Single page per sheet — show each page letterboxed on the selected paper size
     for (let p = 1; p <= totalPages; p++) {
       if (pageRange !== null && !pageRange.has(p)) continue;
-      const { img, naturalW, naturalH } = pageData[p - 1];
+      const { img } = pageData[p - 1];
       const clone = new Image();
       clone.src = img.src;
-      addPreviewPage(clone, naturalW, naturalH);
+      addPreviewPage(clone, paperW, paperH);
     }
   }
 
@@ -254,6 +264,11 @@ chkBooklet.addEventListener('change', () => {
 });
 document.querySelectorAll('input[name="color"]').forEach(el =>
   el.addEventListener('change', updateGreyscale));
+document.querySelectorAll('input[name="orientation"]').forEach(el =>
+  el.addEventListener('change', () => {
+    printOrientation = (document.querySelector('input[name="orientation"]:checked') as HTMLInputElement).value as 'portrait' | 'landscape';
+    renderPreview();
+  }));
 
 btnClose.addEventListener('click', () => window.close());
 
@@ -263,8 +278,7 @@ btnPrint.addEventListener('click', async () => {
   const scaleVal    = selScale.value;
   const scaleFactor = (scaleVal === 'fit' || scaleVal === '100') ? 100 : parseInt(scaleVal);
   const duplexMode  = selDuplex.value as 'simplex' | 'longEdge' | 'shortEdge';
-  // Orientation is handled per-page via CSS @page named pages; always default portrait here
-  const landscape   = false;
+  const landscape   = chkBooklet.checked || printOrientation === 'landscape';
 
   btnPrint.disabled = true;
   statusEl.textContent = 'Printing…';

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -272,6 +272,14 @@ document.querySelectorAll('input[name="orientation"]').forEach(el =>
 
 btnClose.addEventListener('click', () => window.close());
 
+window.addEventListener('wheel', (e: WheelEvent) => {
+  if (!e.ctrlKey) return;
+  e.preventDefault();
+  const curIdx = ZOOM_STEPS.indexOf(previewZoom);
+  if (e.deltaY < 0 && curIdx < ZOOM_STEPS.length - 1) setPreviewZoom(ZOOM_STEPS[curIdx + 1]);
+  if (e.deltaY > 0 && curIdx > 0)                      setPreviewZoom(ZOOM_STEPS[curIdx - 1]);
+}, { passive: false });
+
 btnPrint.addEventListener('click', async () => {
   const copies      = Math.max(1, parseInt(inpCopies.value) || 1);
   const grey        = (document.querySelector('input[name="color"]:checked') as HTMLInputElement)?.value === 'grey';

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -32,23 +32,40 @@ let previewZoom = 1.0;
 let printOrientation: 'portrait' | 'landscape' = 'portrait';
 
 const ZOOM_STEPS = [0.25, 0.33, 0.5, 0.67, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0];
+const ZOOM_MIN = ZOOM_STEPS[0];
+const ZOOM_MAX = ZOOM_STEPS[ZOOM_STEPS.length - 1];
 
 function setPreviewZoom(z: number) {
   previewZoom = z;
   zoomLabel.textContent = `${Math.round(z * 100)}%`;
-  const curIdx = ZOOM_STEPS.indexOf(z);
-  btnZoomOut.disabled = curIdx <= 0;
-  btnZoomIn.disabled  = curIdx >= ZOOM_STEPS.length - 1;
+  btnZoomOut.disabled = z <= ZOOM_MIN;
+  btnZoomIn.disabled  = z >= ZOOM_MAX;
   previewArea.style.zoom = String(z);
 }
 
+function fitToWidth() {
+  if (pageData.length === 0) return;
+  const padding   = 48; // 24px each side
+  const availW    = previewArea.clientWidth - padding;
+  const refW      = pageData[0].naturalW;
+  const refH      = pageData[0].naturalH;
+  const shortSide = Math.min(refW, refH);
+  const longSide  = Math.max(refW, refH);
+  const isBooklet = chkBooklet.checked;
+  const paperW    = isBooklet
+    ? (printOrientation === 'landscape' ? longSide : shortSide) * 2
+    : (printOrientation === 'landscape' ? longSide : shortSide);
+  const z = Math.min(Math.max(availW / paperW, ZOOM_MIN), ZOOM_MAX);
+  setPreviewZoom(Math.round(z * 1000) / 1000);
+}
+
 btnZoomOut.addEventListener('click', () => {
-  const curIdx = ZOOM_STEPS.indexOf(previewZoom);
-  if (curIdx > 0) setPreviewZoom(ZOOM_STEPS[curIdx - 1]);
+  const prev = [...ZOOM_STEPS].reverse().find(s => s < previewZoom - 0.001);
+  if (prev !== undefined) setPreviewZoom(prev);
 });
 btnZoomIn.addEventListener('click', () => {
-  const curIdx = ZOOM_STEPS.indexOf(previewZoom);
-  if (curIdx < ZOOM_STEPS.length - 1) setPreviewZoom(ZOOM_STEPS[curIdx + 1]);
+  const next = ZOOM_STEPS.find(s => s > previewZoom + 0.001);
+  if (next !== undefined) setPreviewZoom(next);
 });
 
 interface PageData {
@@ -267,6 +284,7 @@ document.querySelectorAll('input[name="color"]').forEach(el =>
 document.querySelectorAll('input[name="orientation"]').forEach(el =>
   el.addEventListener('change', () => {
     printOrientation = (document.querySelector('input[name="orientation"]:checked') as HTMLInputElement).value as 'portrait' | 'landscape';
+    fitToWidth();
     renderPreview();
   }));
 
@@ -275,9 +293,8 @@ btnClose.addEventListener('click', () => window.close());
 window.addEventListener('wheel', (e: WheelEvent) => {
   if (!e.ctrlKey) return;
   e.preventDefault();
-  const curIdx = ZOOM_STEPS.indexOf(previewZoom);
-  if (e.deltaY < 0 && curIdx < ZOOM_STEPS.length - 1) setPreviewZoom(ZOOM_STEPS[curIdx + 1]);
-  if (e.deltaY > 0 && curIdx > 0)                      setPreviewZoom(ZOOM_STEPS[curIdx - 1]);
+  if (e.deltaY < 0) { const next = ZOOM_STEPS.find(s => s > previewZoom + 0.001);            if (next !== undefined) setPreviewZoom(next); }
+  if (e.deltaY > 0) { const prev = [...ZOOM_STEPS].reverse().find(s => s < previewZoom - 0.001); if (prev !== undefined) setPreviewZoom(prev); }
 }, { passive: false });
 
 btnPrint.addEventListener('click', async () => {
@@ -357,5 +374,6 @@ window.api.onPdfData(async ({ buffer }) => {
   }
 
   statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;
+  fitToWidth();
   renderPreview();
 });

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -22,9 +22,34 @@ const chkBooklet     = document.getElementById('chk-booklet')      as HTMLInputE
 const btnPrint       = document.getElementById('btn-print')        as HTMLButtonElement;
 const btnClose       = document.getElementById('btn-close')        as HTMLButtonElement;
 const statusEl       = document.getElementById('status')!;
+const btnZoomOut     = document.getElementById('btn-zoom-out')     as HTMLButtonElement;
+const btnZoomIn      = document.getElementById('btn-zoom-in')      as HTMLButtonElement;
+const zoomLabel      = document.getElementById('zoom-label')!;
 
 // ── State ─────────────────────────────────────────────────────
 let totalPages = 0;
+let previewZoom = 1.0;
+
+const ZOOM_STEPS = [0.25, 0.33, 0.5, 0.67, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0];
+
+function setPreviewZoom(z: number) {
+  previewZoom = z;
+  zoomLabel.textContent = `${Math.round(z * 100)}%`;
+  const minIdx = 0, maxIdx = ZOOM_STEPS.length - 1;
+  const curIdx = ZOOM_STEPS.indexOf(z);
+  btnZoomOut.disabled = curIdx <= minIdx;
+  btnZoomIn.disabled  = curIdx >= maxIdx;
+  renderPreview();
+}
+
+btnZoomOut.addEventListener('click', () => {
+  const curIdx = ZOOM_STEPS.indexOf(previewZoom);
+  if (curIdx > 0) setPreviewZoom(ZOOM_STEPS[curIdx - 1]);
+});
+btnZoomIn.addEventListener('click', () => {
+  const curIdx = ZOOM_STEPS.indexOf(previewZoom);
+  if (curIdx < ZOOM_STEPS.length - 1) setPreviewZoom(ZOOM_STEPS[curIdx + 1]);
+});
 
 interface PageData {
   img: HTMLImageElement; // loaded at 1.5× scale
@@ -149,9 +174,12 @@ function buildComposite(pageSlots: number[], cols: number, targetW: number, targ
 
 // ── Add a page wrapper to the preview ────────────────────────
 function addPreviewPage(imgEl: HTMLImageElement, displayW: number, displayH: number) {
-  imgEl.style.cssText = `width:${displayW}px; height:${displayH}px; max-width:100%;`;
+  const scaledW = Math.round(displayW * previewZoom);
+  const scaledH = Math.round(displayH * previewZoom);
+  imgEl.style.cssText = `width:${scaledW}px; height:${scaledH}px; max-width:100%;`;
   const wrapper = document.createElement('div');
   wrapper.className = 'print-page';
+  if (displayW > displayH) wrapper.classList.add('landscape');
   wrapper.appendChild(imgEl);
   previewArea.appendChild(wrapper);
 }
@@ -239,9 +267,8 @@ btnPrint.addEventListener('click', async () => {
   const scaleVal    = selScale.value;
   const scaleFactor = (scaleVal === 'fit' || scaleVal === '100') ? 100 : parseInt(scaleVal);
   const duplexMode  = selDuplex.value as 'simplex' | 'longEdge' | 'shortEdge';
-  // Booklet composites are always landscape; otherwise follow the first page's orientation
-  const landscape   = chkBooklet.checked ||
-    (pageData.length > 0 && pageData[0].naturalW > pageData[0].naturalH);
+  // Orientation is handled per-page via CSS @page named pages; always default portrait here
+  const landscape   = false;
 
   btnPrint.disabled = true;
   statusEl.textContent = 'Printing…';

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -101,8 +101,10 @@ btnPrinterPref.addEventListener('click', () => {
 });
 
 // ── Page range parsing ────────────────────────────────────────
-// Returns null for "all pages", or a Set<number> of selected page numbers.
-function parsePageRange(str: string): Set<number> | null {
+// Returns null for "all pages" (empty input), a non-empty Set<number> for a
+// valid range, or false when the input is non-empty but resolves to no pages
+// (reversed range, out-of-range values, etc.).
+function parsePageRange(str: string): Set<number> | null | false {
   const trimmed = str.trim();
   if (!trimmed) return null;
   const result = new Set<number>();
@@ -117,7 +119,7 @@ function parsePageRange(str: string): Set<number> | null {
       if (!isNaN(n) && n >= 1 && n <= totalPages) result.add(n);
     }
   }
-  return result;
+  return result.size > 0 ? result : false;
 }
 
 // ── Booklet ordering ──────────────────────────────────────────
@@ -210,6 +212,13 @@ function renderPreview() {
   const isBooklet = chkBooklet.checked;
   const pps       = isBooklet ? 2 : (parseInt(selPps.value) || 1);
   const pageRange = parsePageRange(inpPages.value);
+
+  if (pageRange === false) {
+    inpPages.setCustomValidity('No pages match this range.');
+    inpPages.reportValidity();
+    return;
+  }
+  inpPages.setCustomValidity('');
 
   // Reference dimensions (first page at 1× scale)
   const refW = pageData[0].naturalW;
@@ -305,6 +314,12 @@ btnPrint.addEventListener('click', async () => {
   const scaleFactor = (scaleVal === 'fit' || scaleVal === '100') ? 100 : parseInt(scaleVal);
   const duplexMode  = selDuplex.value as 'simplex' | 'longEdge' | 'shortEdge';
   const landscape   = chkBooklet.checked || printOrientation === 'landscape';
+
+  if (parsePageRange(inpPages.value) === false) {
+    inpPages.setCustomValidity('No pages match this range.');
+    inpPages.reportValidity();
+    return;
+  }
 
   if (failedPages.length > 0) {
     const n = failedPages.length;

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -75,6 +75,7 @@ interface PageData {
 }
 const pageData: PageData[] = []; // index 0 = page 1
 const failedPages: number[] = []; // 1-based page numbers that failed to render as PNG
+let _compositeUrls: string[] = []; // blob URLs for composite renders; revoked before each rebuild
 
 // ── Printers ──────────────────────────────────────────────────
 (async () => {
@@ -148,7 +149,7 @@ function getBookletOrder(numPages: number): BookletSheet[] {
 // pageSlots: 1-indexed page numbers; 0 or >totalPages means blank
 // cols: number of columns in the grid
 // targetW/H: canvas output size in px
-function buildComposite(pageSlots: number[], cols: number, targetW: number, targetH: number): HTMLImageElement {
+async function buildComposite(pageSlots: number[], cols: number, targetW: number, targetH: number): Promise<HTMLImageElement> {
   const rows = Math.ceil(pageSlots.length / cols);
   const canvas = document.createElement('canvas');
   canvas.width  = targetW;
@@ -187,8 +188,13 @@ function buildComposite(pageSlots: number[], cols: number, targetW: number, targ
     ctx.strokeRect(slotX + 0.25, slotY + 0.25, slotW - 0.5, slotH - 0.5);
   });
 
+  const blob = await new Promise<Blob>((resolve, reject) =>
+    canvas.toBlob(b => b ? resolve(b) : reject(new Error('canvas.toBlob failed')), 'image/png')
+  );
+  const url = URL.createObjectURL(blob);
+  _compositeUrls.push(url);
   const out = new Image();
-  out.src = canvas.toDataURL('image/png');
+  await new Promise<void>(resolve => { out.onload = () => resolve(); out.src = url; });
   return out;
 }
 
@@ -205,8 +211,13 @@ function addPreviewPage(imgEl: HTMLImageElement, paperW: number, paperH: number)
 }
 
 // ── Build / refresh the preview ───────────────────────────────
-function renderPreview() {
+async function renderPreview() {
   if (pageData.length === 0) return;
+
+  // Revoke blob URLs from the previous render before rebuilding.
+  _compositeUrls.forEach(u => URL.revokeObjectURL(u));
+  _compositeUrls = [];
+
   previewArea.innerHTML = '';
 
   const isBooklet = chkBooklet.checked;
@@ -233,13 +244,13 @@ function renderPreview() {
   if (isBooklet) {
     // Booklet: always uses all pages; composites are landscape (2× wide)
     const sheets = getBookletOrder(totalPages);
-    sheets.forEach(sheet => {
-      (['front', 'back'] as const).forEach(side => {
+    for (const sheet of sheets) {
+      for (const side of ['front', 'back'] as const) {
         const [lp, rp] = sheet[side];
-        const img = buildComposite([lp, rp], 2, paperW * 2, paperH);
+        const img = await buildComposite([lp, rp], 2, paperW * 2, paperH);
         addPreviewPage(img, paperW * 2, paperH);
-      });
-    });
+      }
+    }
   } else if (pps > 1) {
     // Pages per sheet: group visible pages into chunks, create composite
     const PPS_COLS: Record<number, number> = { 2: 2, 4: 2, 6: 3, 9: 3, 16: 4 };
@@ -252,7 +263,7 @@ function renderPreview() {
     for (let i = 0; i < visible.length; i += pps) {
       const chunk = visible.slice(i, i + pps);
       while (chunk.length < pps) chunk.push(0); // pad with blanks
-      const img = buildComposite(chunk, cols, paperW, paperH);
+      const img = await buildComposite(chunk, cols, paperW, paperH);
       addPreviewPage(img, paperW, paperH);
     }
   } else {

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -74,6 +74,7 @@ interface PageData {
   naturalH: number;      // 1× CSS height
 }
 const pageData: PageData[] = []; // index 0 = page 1
+const failedPages: number[] = []; // 1-based page numbers that failed to render as PNG
 
 // ── Printers ──────────────────────────────────────────────────
 (async () => {
@@ -305,6 +306,12 @@ btnPrint.addEventListener('click', async () => {
   const duplexMode  = selDuplex.value as 'simplex' | 'longEdge' | 'shortEdge';
   const landscape   = chkBooklet.checked || printOrientation === 'landscape';
 
+  if (failedPages.length > 0) {
+    const n = failedPages.length;
+    const ok = confirm(`${n} page${n === 1 ? '' : 's'} (${failedPages.join(', ')}) failed to render and will print blank. Continue anyway?`);
+    if (!ok) return;
+  }
+
   btnPrint.disabled = true;
   statusEl.textContent = 'Printing…';
   try {
@@ -357,7 +364,7 @@ window.api.onPdfData(async ({ buffer }) => {
       const img      = new Image();
       await new Promise<void>(resolve => {
         img.onload  = () => resolve();
-        img.onerror = () => resolve(); // silently skip bad frames
+        img.onerror = () => { failedPages.push(pageNum); resolve(); };
         img.src = dataUrl;
       });
 
@@ -373,7 +380,11 @@ window.api.onPdfData(async ({ buffer }) => {
     return;
   }
 
-  statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;
+  if (failedPages.length > 0) {
+    statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'} — warning: ${failedPages.length} page${failedPages.length === 1 ? '' : 's'} failed to render (pages ${failedPages.join(', ')}) and will print blank`;
+  } else {
+    statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;
+  }
   fitToWidth();
   renderPreview();
 });

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -73,7 +73,7 @@ interface PageData {
   naturalW: number;      // 1× CSS width (viewport.width / 1.5)
   naturalH: number;      // 1× CSS height
 }
-let pageData: PageData[] = []; // index 0 = page 1
+const pageData: PageData[] = []; // index 0 = page 1
 
 // ── Printers ──────────────────────────────────────────────────
 (async () => {

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -35,11 +35,10 @@ const ZOOM_STEPS = [0.25, 0.33, 0.5, 0.67, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75,
 function setPreviewZoom(z: number) {
   previewZoom = z;
   zoomLabel.textContent = `${Math.round(z * 100)}%`;
-  const minIdx = 0, maxIdx = ZOOM_STEPS.length - 1;
   const curIdx = ZOOM_STEPS.indexOf(z);
-  btnZoomOut.disabled = curIdx <= minIdx;
-  btnZoomIn.disabled  = curIdx >= maxIdx;
-  renderPreview();
+  btnZoomOut.disabled = curIdx <= 0;
+  btnZoomIn.disabled  = curIdx >= ZOOM_STEPS.length - 1;
+  previewArea.style.zoom = String(z);
 }
 
 btnZoomOut.addEventListener('click', () => {
@@ -174,9 +173,7 @@ function buildComposite(pageSlots: number[], cols: number, targetW: number, targ
 
 // ── Add a page wrapper to the preview ────────────────────────
 function addPreviewPage(imgEl: HTMLImageElement, displayW: number, displayH: number) {
-  const scaledW = Math.round(displayW * previewZoom);
-  const scaledH = Math.round(displayH * previewZoom);
-  imgEl.style.cssText = `width:${scaledW}px; height:${scaledH}px; max-width:100%;`;
+  imgEl.style.cssText = `width:${displayW}px; height:${displayH}px;`;
   const wrapper = document.createElement('div');
   wrapper.className = 'print-page';
   wrapper.appendChild(imgEl);

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -1,0 +1,109 @@
+// Reamlet — Print Preview renderer
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// @ts-expect-error — pdfjs-dist direct path for Electron ESM
+import * as _pdfjsLib from '../../node_modules/pdfjs-dist/build/pdf.mjs';
+import type * as PDFJSLib from 'pdfjs-dist';
+const pdfjsLib = _pdfjsLib as unknown as typeof PDFJSLib;
+pdfjsLib.GlobalWorkerOptions.workerSrc =
+  new URL('../../node_modules/pdfjs-dist/build/pdf.worker.mjs', import.meta.url).href;
+
+const previewArea    = document.getElementById('preview-area')!;
+const inpCopies      = document.getElementById('inp-copies')      as HTMLInputElement;
+const selPages       = document.getElementById('sel-pages')       as HTMLSelectElement;
+const inpPagesCustom = document.getElementById('inp-pages-custom') as HTMLInputElement;
+const selScale       = document.getElementById('sel-scale')       as HTMLSelectElement;
+const btnPrint       = document.getElementById('btn-print')       as HTMLButtonElement;
+const btnClose       = document.getElementById('btn-close')       as HTMLButtonElement;
+const statusEl       = document.getElementById('status')!;
+
+let totalPages = 0;
+
+// Parse "1-3, 5, 7-9" into Set<number>
+function parsePageRange(str: string, total: number): Set<number> {
+  const result = new Set<number>();
+  for (const part of str.split(',')) {
+    const trimmed = part.trim();
+    const range = trimmed.match(/^(\d+)\s*[-\u2013]\s*(\d+)$/);
+    if (range) {
+      const from = parseInt(range[1]), to = parseInt(range[2]);
+      for (let p = Math.max(1, from); p <= Math.min(total, to); p++) result.add(p);
+    } else {
+      const n = parseInt(trimmed);
+      if (!isNaN(n) && n >= 1 && n <= total) result.add(n);
+    }
+  }
+  return result;
+}
+
+function updatePageVisibility() {
+  const mode = selPages.value;
+  const selected = mode === 'custom' && inpPagesCustom.value.trim()
+    ? parsePageRange(inpPagesCustom.value, totalPages)
+    : null; // null = all
+  document.querySelectorAll<HTMLElement>('.print-page').forEach(el => {
+    const page = parseInt(el.dataset.page!);
+    el.classList.toggle('excluded', selected !== null && !selected.has(page));
+  });
+}
+
+function updateGreyscale() {
+  const grey = (document.querySelector('input[name="color"]:checked') as HTMLInputElement)?.value === 'grey';
+  previewArea.classList.toggle('greyscale', grey);
+}
+
+function updateScale() {
+  const fit = selScale.value === 'fit';
+  document.querySelectorAll('.print-page').forEach(el => el.classList.toggle('fit', fit));
+}
+
+selPages.addEventListener('change', () => {
+  inpPagesCustom.classList.toggle('hidden', selPages.value !== 'custom');
+  updatePageVisibility();
+});
+inpPagesCustom.addEventListener('input', updatePageVisibility);
+document.querySelectorAll('input[name="color"]').forEach(el =>
+  el.addEventListener('change', updateGreyscale));
+selScale.addEventListener('change', updateScale);
+
+btnClose.addEventListener('click', () => window.close());
+
+btnPrint.addEventListener('click', async () => {
+  const copies   = Math.max(1, parseInt(inpCopies.value) || 1);
+  const grey     = (document.querySelector('input[name="color"]:checked') as HTMLInputElement)?.value === 'grey';
+  const scaleVal = selScale.value;
+  const scaleFactor = scaleVal === 'fit' || scaleVal === '100' ? 100 : parseInt(scaleVal);
+
+  btnPrint.disabled = true;
+  await window.api.executePrint({ copies, color: !grey, scaleFactor });
+  btnPrint.disabled = false;
+});
+
+window.api.onPdfData(async ({ buffer }) => {
+  statusEl.textContent = 'Rendering pages…';
+  const bytes  = new Uint8Array(buffer);
+  const pdfDoc = await pdfjsLib.getDocument({ data: bytes }).promise;
+  totalPages   = pdfDoc.numPages;
+
+  for (let pageNum = 1; pageNum <= totalPages; pageNum++) {
+    const page     = await pdfDoc.getPage(pageNum);
+    const viewport = page.getViewport({ scale: 1.5 });
+    const canvas   = document.createElement('canvas');
+    canvas.width   = viewport.width;
+    canvas.height  = viewport.height;
+    await page.render({ canvasContext: canvas.getContext('2d')!, viewport }).promise;
+
+    const img   = new Image();
+    img.src     = canvas.toDataURL('image/png');
+    img.style.cssText = `width: ${viewport.width / 1.5}px; height: auto;`;
+
+    const wrapper       = document.createElement('div');
+    wrapper.className   = 'print-page fit'; // fit is default
+    wrapper.dataset.page = String(pageNum);
+    wrapper.appendChild(img);
+    previewArea.appendChild(wrapper);
+  }
+
+  statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;
+  updateScale(); // apply initial scale state
+});

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -8,43 +8,194 @@ const pdfjsLib = _pdfjsLib as unknown as typeof PDFJSLib;
 pdfjsLib.GlobalWorkerOptions.workerSrc =
   new URL('../../node_modules/pdfjs-dist/build/pdf.worker.mjs', import.meta.url).href;
 
+// ── DOM refs ──────────────────────────────────────────────────
 const previewArea    = document.getElementById('preview-area')!;
-const inpCopies      = document.getElementById('inp-copies')      as HTMLInputElement;
-const selPages       = document.getElementById('sel-pages')       as HTMLSelectElement;
-const inpPagesCustom = document.getElementById('inp-pages-custom') as HTMLInputElement;
-const selScale       = document.getElementById('sel-scale')       as HTMLSelectElement;
-const btnPrint       = document.getElementById('btn-print')       as HTMLButtonElement;
-const btnClose       = document.getElementById('btn-close')       as HTMLButtonElement;
+const selPrinter     = document.getElementById('sel-printer')      as HTMLSelectElement;
+const btnPrinterPref = document.getElementById('btn-printer-pref') as HTMLButtonElement;
+const inpCopies      = document.getElementById('inp-copies')       as HTMLInputElement;
+const chkCollate     = document.getElementById('chk-collate')      as HTMLInputElement;
+const inpPages       = document.getElementById('inp-pages')        as HTMLInputElement;
+const selScale       = document.getElementById('sel-scale')        as HTMLSelectElement;
+const selPps         = document.getElementById('sel-pps')          as HTMLSelectElement;
+const selDuplex      = document.getElementById('sel-duplex')       as HTMLSelectElement;
+const chkBooklet     = document.getElementById('chk-booklet')      as HTMLInputElement;
+const btnPrint       = document.getElementById('btn-print')        as HTMLButtonElement;
+const btnClose       = document.getElementById('btn-close')        as HTMLButtonElement;
 const statusEl       = document.getElementById('status')!;
 
+// ── State ─────────────────────────────────────────────────────
 let totalPages = 0;
 
-// Parse "1-3, 5, 7-9" into Set<number>
-function parsePageRange(str: string, total: number): Set<number> {
+interface PageData {
+  img: HTMLImageElement; // loaded at 1.5× scale
+  naturalW: number;      // 1× CSS width (viewport.width / 1.5)
+  naturalH: number;      // 1× CSS height
+}
+let pageData: PageData[] = []; // index 0 = page 1
+
+// ── Printers ──────────────────────────────────────────────────
+(async () => {
+  const printers = await window.api.getPrinters();
+  selPrinter.innerHTML = '';
+  if (printers.length === 0) {
+    const opt = document.createElement('option');
+    opt.textContent = 'No printers found';
+    selPrinter.appendChild(opt);
+    return;
+  }
+  printers.forEach((p: { name: string; isDefault: boolean }) => {
+    const opt = document.createElement('option');
+    opt.value = p.name;
+    opt.textContent = p.name;
+    if (p.isDefault) opt.selected = true;
+    selPrinter.appendChild(opt);
+  });
+})();
+
+btnPrinterPref.addEventListener('click', () => {
+  if (selPrinter.value) window.api.openPrinterPreferences(selPrinter.value);
+});
+
+// ── Page range parsing ────────────────────────────────────────
+// Returns null for "all pages", or a Set<number> of selected page numbers.
+function parsePageRange(str: string): Set<number> | null {
+  const trimmed = str.trim();
+  if (!trimmed) return null;
   const result = new Set<number>();
-  for (const part of str.split(',')) {
-    const trimmed = part.trim();
-    const range = trimmed.match(/^(\d+)\s*[-\u2013]\s*(\d+)$/);
-    if (range) {
-      const from = parseInt(range[1]), to = parseInt(range[2]);
-      for (let p = Math.max(1, from); p <= Math.min(total, to); p++) result.add(p);
+  for (const part of trimmed.split(',')) {
+    const t = part.trim();
+    const rangeMatch = t.match(/^(\d+)\s*[-\u2013]\s*(\d+)$/);
+    if (rangeMatch) {
+      const from = parseInt(rangeMatch[1]), to = parseInt(rangeMatch[2]);
+      for (let p = Math.max(1, from); p <= Math.min(totalPages, to); p++) result.add(p);
     } else {
-      const n = parseInt(trimmed);
-      if (!isNaN(n) && n >= 1 && n <= total) result.add(n);
+      const n = parseInt(t);
+      if (!isNaN(n) && n >= 1 && n <= totalPages) result.add(n);
     }
   }
-  return result;
+  return result.size > 0 ? result : null;
 }
 
-function updatePageVisibility() {
-  const mode = selPages.value;
-  const selected = mode === 'custom' && inpPagesCustom.value.trim()
-    ? parsePageRange(inpPagesCustom.value, totalPages)
-    : null; // null = all
-  document.querySelectorAll<HTMLElement>('.print-page').forEach(el => {
-    const page = parseInt(el.dataset.page!);
-    el.classList.toggle('excluded', selected !== null && !selected.has(page));
+// ── Booklet ordering ──────────────────────────────────────────
+interface BookletSheet {
+  front: [number, number]; // [leftPage, rightPage] — both 1-indexed; 0 = blank
+  back:  [number, number];
+}
+
+function getBookletOrder(numPages: number): BookletSheet[] {
+  const totalSlots = Math.ceil(numPages / 4) * 4;
+  const numSheets  = totalSlots / 4;
+  const sheets: BookletSheet[] = [];
+  let low = 1, high = totalSlots;
+  for (let i = 0; i < numSheets; i++) {
+    // Per spec: front=[high, low], back=[low+1, high-1]
+    // "right page is high, left page is low" in the spec, but we render [left=high, right=low]
+    // which matches physical booklet layout (high=back_cover on left, low=front_cover on right)
+    sheets.push({ front: [high, low], back: [low + 1, high - 1] });
+    low  += 2;
+    high -= 2;
+  }
+  return sheets;
+}
+
+// ── Composite image builder ───────────────────────────────────
+// pageSlots: 1-indexed page numbers; 0 or >totalPages means blank
+// cols: number of columns in the grid
+// targetW/H: canvas output size in px
+function buildComposite(pageSlots: number[], cols: number, targetW: number, targetH: number): HTMLImageElement {
+  const rows = Math.ceil(pageSlots.length / cols);
+  const canvas = document.createElement('canvas');
+  canvas.width  = targetW;
+  canvas.height = targetH;
+  const ctx = canvas.getContext('2d')!;
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, targetW, targetH);
+
+  const slotW = targetW / cols;
+  const slotH = targetH / rows;
+
+  pageSlots.forEach((pageNum, idx) => {
+    const col  = idx % cols;
+    const row  = Math.floor(idx / cols);
+    const slotX = col * slotW;
+    const slotY = row * slotH;
+
+    if (pageNum >= 1 && pageNum <= totalPages) {
+      const { img, naturalW, naturalH } = pageData[pageNum - 1];
+      const scale = Math.min(slotW / naturalW, slotH / naturalH);
+      const dw = naturalW * scale, dh = naturalH * scale;
+      ctx.drawImage(img, slotX + (slotW - dw) / 2, slotY + (slotH - dh) / 2, dw, dh);
+    }
+    // Faint slot border
+    ctx.strokeStyle = '#ddd';
+    ctx.lineWidth = 0.5;
+    ctx.strokeRect(slotX + 0.25, slotY + 0.25, slotW - 0.5, slotH - 0.5);
   });
+
+  const out = new Image();
+  out.src = canvas.toDataURL('image/png');
+  return out;
+}
+
+// ── Add a page wrapper to the preview ────────────────────────
+function addPreviewPage(imgEl: HTMLImageElement, displayW: number, displayH: number) {
+  imgEl.style.cssText = `width:${displayW}px; height:${displayH}px; max-width:100%;`;
+  const wrapper = document.createElement('div');
+  wrapper.className = 'print-page';
+  wrapper.appendChild(imgEl);
+  previewArea.appendChild(wrapper);
+}
+
+// ── Build / refresh the preview ───────────────────────────────
+function renderPreview() {
+  if (pageData.length === 0) return;
+  previewArea.innerHTML = '';
+
+  const isBooklet = chkBooklet.checked;
+  const pps       = isBooklet ? 2 : (parseInt(selPps.value) || 1);
+  const pageRange = parsePageRange(inpPages.value);
+
+  // Reference dimensions (first page at 1× scale)
+  const refW = pageData[0].naturalW;
+  const refH = pageData[0].naturalH;
+
+  if (isBooklet) {
+    // Booklet: always uses all pages; composites are landscape (2× wide)
+    const sheets = getBookletOrder(totalPages);
+    sheets.forEach(sheet => {
+      (['front', 'back'] as const).forEach(side => {
+        const [lp, rp] = sheet[side];
+        const img = buildComposite([lp, rp], 2, refW * 2, refH);
+        addPreviewPage(img, refW * 2, refH);
+      });
+    });
+  } else if (pps > 1) {
+    // Pages per sheet: group visible pages into chunks, create composite
+    const PPS_COLS: Record<number, number> = { 2: 2, 4: 2, 6: 3, 9: 3, 16: 4 };
+    const cols = PPS_COLS[pps] ?? 2;
+
+    const visible: number[] = [];
+    for (let p = 1; p <= totalPages; p++) {
+      if (pageRange === null || pageRange.has(p)) visible.push(p);
+    }
+    for (let i = 0; i < visible.length; i += pps) {
+      const chunk = visible.slice(i, i + pps);
+      while (chunk.length < pps) chunk.push(0); // pad with blanks
+      const img = buildComposite(chunk, cols, refW, refH);
+      addPreviewPage(img, refW, refH);
+    }
+  } else {
+    // Single page per sheet
+    for (let p = 1; p <= totalPages; p++) {
+      if (pageRange !== null && !pageRange.has(p)) continue;
+      const { img, naturalW, naturalH } = pageData[p - 1];
+      const clone = new Image();
+      clone.src = img.src;
+      addPreviewPage(clone, naturalW, naturalH);
+    }
+  }
+
+  updateGreyscale();
 }
 
 function updateGreyscale() {
@@ -52,33 +203,49 @@ function updateGreyscale() {
   previewArea.classList.toggle('greyscale', grey);
 }
 
-function updateScale() {
-  const fit = selScale.value === 'fit';
-  document.querySelectorAll('.print-page').forEach(el => el.classList.toggle('fit', fit));
-}
-
-selPages.addEventListener('change', () => {
-  inpPagesCustom.classList.toggle('hidden', selPages.value !== 'custom');
-  updatePageVisibility();
+// ── Event wiring ──────────────────────────────────────────────
+inpPages.addEventListener('input',    renderPreview);
+selPps.addEventListener('change',     () => { if (!chkBooklet.checked) renderPreview(); });
+chkBooklet.addEventListener('change', () => {
+  if (chkBooklet.checked) {
+    selPps.value    = '2';
+    selDuplex.value = 'shortEdge';
+    selPps.disabled = true;
+  } else {
+    selPps.value    = '1';
+    selDuplex.value = 'simplex';
+    selPps.disabled = false;
+  }
+  renderPreview();
 });
-inpPagesCustom.addEventListener('input', updatePageVisibility);
 document.querySelectorAll('input[name="color"]').forEach(el =>
   el.addEventListener('change', updateGreyscale));
-selScale.addEventListener('change', updateScale);
 
 btnClose.addEventListener('click', () => window.close());
 
 btnPrint.addEventListener('click', async () => {
-  const copies   = Math.max(1, parseInt(inpCopies.value) || 1);
-  const grey     = (document.querySelector('input[name="color"]:checked') as HTMLInputElement)?.value === 'grey';
-  const scaleVal = selScale.value;
-  const scaleFactor = scaleVal === 'fit' || scaleVal === '100' ? 100 : parseInt(scaleVal);
+  const copies      = Math.max(1, parseInt(inpCopies.value) || 1);
+  const grey        = (document.querySelector('input[name="color"]:checked') as HTMLInputElement)?.value === 'grey';
+  const scaleVal    = selScale.value;
+  const scaleFactor = (scaleVal === 'fit' || scaleVal === '100') ? 100 : parseInt(scaleVal);
+  const duplexMode  = selDuplex.value as 'simplex' | 'longEdge' | 'shortEdge';
+  const landscape   = chkBooklet.checked; // booklet composites are landscape
 
   btnPrint.disabled = true;
-  await window.api.executePrint({ copies, color: !grey, scaleFactor });
-  btnPrint.disabled = false;
+  statusEl.textContent = 'Printing…';
+  await window.api.executePrint({
+    deviceName: selPrinter.value,
+    copies,
+    color:      !grey,
+    collate:    chkCollate.checked,
+    duplexMode,
+    scaleFactor,
+    landscape,
+  });
+  window.close();
 });
 
+// ── Receive PDF data from main ─────────────────────────────────
 window.api.onPdfData(async ({ buffer }) => {
   statusEl.textContent = 'Rendering pages…';
   const bytes  = new Uint8Array(buffer);
@@ -93,17 +260,18 @@ window.api.onPdfData(async ({ buffer }) => {
     canvas.height  = viewport.height;
     await page.render({ canvasContext: canvas.getContext('2d')!, viewport }).promise;
 
-    const img   = new Image();
-    img.src     = canvas.toDataURL('image/png');
-    img.style.cssText = `width: ${viewport.width / 1.5}px; height: auto;`;
+    const dataUrl  = canvas.toDataURL('image/png');
+    const img      = new Image();
+    await new Promise<void>(resolve => { img.onload = () => resolve(); img.src = dataUrl; });
 
-    const wrapper       = document.createElement('div');
-    wrapper.className   = 'print-page fit'; // fit is default
-    wrapper.dataset.page = String(pageNum);
-    wrapper.appendChild(img);
-    previewArea.appendChild(wrapper);
+    pageData.push({
+      img,
+      naturalW: viewport.width  / 1.5,
+      naturalH: viewport.height / 1.5,
+    });
+    statusEl.textContent = `Rendering… ${pageNum}/${totalPages}`;
   }
 
   statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;
-  updateScale(); // apply initial scale state
+  renderPreview();
 });

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -179,7 +179,6 @@ function addPreviewPage(imgEl: HTMLImageElement, displayW: number, displayH: num
   imgEl.style.cssText = `width:${scaledW}px; height:${scaledH}px; max-width:100%;`;
   const wrapper = document.createElement('div');
   wrapper.className = 'print-page';
-  if (displayW > displayH) wrapper.classList.add('landscape');
   wrapper.appendChild(imgEl);
   previewArea.appendChild(wrapper);
 }

--- a/src/renderer/saver.ts
+++ b/src/renderer/saver.ts
@@ -86,15 +86,15 @@ export async function embedAnnotations(pdfBytes: Uint8Array, annotations: Annota
  * Rotation is the total display rotation (base PDF /Rotate + user rotation).
  * Formulas derived from inverting the PDF.js viewport transform:
  *   rot=0:   pdf = (nx·W,     (1-ny)·H)
- *   rot=90:  pdf = ((1-ny)·W, (1-nx)·H)
+ *   rot=90:  pdf = (ny·W,     nx·H)
  *   rot=180: pdf = ((1-nx)·W, ny·H)
- *   rot=270: pdf = (ny·W,     nx·H)
+ *   rot=270: pdf = ((1-ny)·W, (1-nx)·H)
  */
 function toPdfCoords(nx: number, ny: number, pdfW: number, pdfH: number, rot: number): [number, number] {
   switch ((rot || 0) % 360) {
-    case 90:  return [(1 - ny) * pdfW, (1 - nx) * pdfH];
+    case 90:  return [       ny * pdfW,        nx * pdfH];
     case 180: return [(1 - nx) * pdfW,        ny * pdfH];
-    case 270: return [       ny * pdfW,        nx * pdfH];
+    case 270: return [(1 - ny) * pdfW, (1 - nx) * pdfH];
     default:  return [       nx * pdfW, (1 - ny) * pdfH];
   }
 }

--- a/src/renderer/saver.ts
+++ b/src/renderer/saver.ts
@@ -61,17 +61,16 @@ export async function embedAnnotations(pdfBytes: Uint8Array, annotations: Annota
 
     const { width: pdfW, height: pdfH } = await viewer.getPageSize(pageNum);
     const totalRot = viewer.getTotalRotation(pageNum);
-    const scale    = viewer.scale;
 
     for (const ann of pageAnns) {
-      if      (ann.type === 'draw')          _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
-      else if (ann.type === 'freeHighlight') _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
+      if      (ann.type === 'draw')          _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot);
+      else if (ann.type === 'freeHighlight') _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot);
       else if (ann.type === 'highlight')     _addHighlightAnnotation(pdfPage, ann,           pdfW, pdfH, totalRot);
       else if (ann.type === 'text')          _addFreeTextAnnotation (pdfPage, ann,           pdfW, pdfH, totalRot);
-      else if (ann.type === 'line')          _addLineAnnotation     (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
-      else if (ann.type === 'arrow')         _addArrowAnnotation    (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
-      else if (ann.type === 'rect')          _addSquareAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
-      else if (ann.type === 'oval')          _addCircleAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
+      else if (ann.type === 'line')          _addLineAnnotation     (pdfPage, ann,           pdfW, pdfH, totalRot);
+      else if (ann.type === 'arrow')         _addArrowAnnotation    (pdfPage, ann,           pdfW, pdfH, totalRot);
+      else if (ann.type === 'rect')          _addSquareAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot);
+      else if (ann.type === 'oval')          _addCircleAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot);
     }
   }
 
@@ -109,9 +108,8 @@ function hexToRgb01(hex: string): { r: number; g: number; b: number } {
 
 // ── Annotation writers ───────────────────────────────────────
 
-function _addInkAnnotation(pdfPage: PDFPage, ann: DrawAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
+function _addInkAnnotation(pdfPage: PDFPage, ann: DrawAnnotation, pdfW: number, pdfH: number, rot: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
-  const w = ann.thickness / scale; // canvas px → PDF pts
 
   const inkPoints = ann.points.flatMap(([nx, ny]: [number, number]) => {
     const [x, y] = toPdfCoords(nx, ny, pdfW, pdfH, rot);
@@ -123,14 +121,14 @@ function _addInkAnnotation(pdfPage: PDFPage, ann: DrawAnnotation, pdfW: number, 
   const pdfPts = ann.points.map(([nx, ny]: [number, number]) => toPdfCoords(nx, ny, pdfW, pdfH, rot));
   const xs  = pdfPts.map(([x]: [number, number]) => x);
   const ys  = pdfPts.map(([, y]: [number, number]) => y);
-  const pad = w;
+  const pad = ann.thickness;
 
   const annotDict = pdfPage.doc.context.obj({
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Ink'),
     Rect:    [Math.min(...xs) - pad, Math.min(...ys) - pad, Math.max(...xs) + pad, Math.max(...ys) + pad],
     InkList: inkList,
-    BS:      pdfPage.doc.context.obj({ W: w }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
     C:       [r, g, b],
     CA:      PDFNumber.of(ann.type === 'freeHighlight' ? 0.4 : 1),
     F:       PDFNumber.of(4),
@@ -190,44 +188,42 @@ function _addFreeTextAnnotation(pdfPage: PDFPage, ann: TextAnnotation, pdfW: num
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addLineAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
+function _addLineAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
-  const w   = ann.thickness / scale;
-  const pad = w;
+  const pad = ann.thickness;
   const annotDict = pdfPage.doc.context.obj({
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Line'),
     Rect:    [Math.min(x1,x2)-pad, Math.min(y1,y2)-pad, Math.max(x1,x2)+pad, Math.max(y1,y2)+pad],
     L:       [x1, y1, x2, y2],
-    BS:      pdfPage.doc.context.obj({ W: w }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addArrowAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
+function _addArrowAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
-  const w   = ann.thickness / scale;
-  const pad = w * 5;
+  const pad = ann.thickness * 5;
   const annotDict = pdfPage.doc.context.obj({
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Line'),
     Rect:    [Math.min(x1,x2)-pad, Math.min(y1,y2)-pad, Math.max(x1,x2)+pad, Math.max(y1,y2)+pad],
     L:       [x1, y1, x2, y2],
     LE:      [PDFName.of('None'), PDFName.of('OpenArrow')],
-    BS:      pdfPage.doc.context.obj({ W: w }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addSquareAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
+function _addSquareAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
@@ -235,14 +231,14 @@ function _addSquareAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: numb
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Square'),
     Rect:    [Math.min(x1,x2), Math.min(y1,y2), Math.max(x1,x2), Math.max(y1,y2)],
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness / scale }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
+function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
@@ -250,7 +246,7 @@ function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: numb
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Circle'),
     Rect:    [Math.min(x1,x2), Math.min(y1,y2), Math.max(x1,x2), Math.max(y1,y2)],
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness / scale }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });

--- a/src/renderer/saver.ts
+++ b/src/renderer/saver.ts
@@ -61,16 +61,17 @@ export async function embedAnnotations(pdfBytes: Uint8Array, annotations: Annota
 
     const { width: pdfW, height: pdfH } = await viewer.getPageSize(pageNum);
     const totalRot = viewer.getTotalRotation(pageNum);
+    const scale    = viewer.scale;
 
     for (const ann of pageAnns) {
-      if      (ann.type === 'draw')          _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot);
-      else if (ann.type === 'freeHighlight') _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot);
+      if      (ann.type === 'draw')          _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
+      else if (ann.type === 'freeHighlight') _addInkAnnotation      (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
       else if (ann.type === 'highlight')     _addHighlightAnnotation(pdfPage, ann,           pdfW, pdfH, totalRot);
       else if (ann.type === 'text')          _addFreeTextAnnotation (pdfPage, ann,           pdfW, pdfH, totalRot);
-      else if (ann.type === 'line')          _addLineAnnotation     (pdfPage, ann,           pdfW, pdfH, totalRot);
-      else if (ann.type === 'arrow')         _addArrowAnnotation    (pdfPage, ann,           pdfW, pdfH, totalRot);
-      else if (ann.type === 'rect')          _addSquareAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot);
-      else if (ann.type === 'oval')          _addCircleAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot);
+      else if (ann.type === 'line')          _addLineAnnotation     (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
+      else if (ann.type === 'arrow')         _addArrowAnnotation    (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
+      else if (ann.type === 'rect')          _addSquareAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
+      else if (ann.type === 'oval')          _addCircleAnnotation   (pdfPage, ann,           pdfW, pdfH, totalRot, scale);
     }
   }
 
@@ -108,8 +109,9 @@ function hexToRgb01(hex: string): { r: number; g: number; b: number } {
 
 // ── Annotation writers ───────────────────────────────────────
 
-function _addInkAnnotation(pdfPage: PDFPage, ann: DrawAnnotation, pdfW: number, pdfH: number, rot: number): void {
+function _addInkAnnotation(pdfPage: PDFPage, ann: DrawAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
+  const w = ann.thickness / scale; // canvas px → PDF pts
 
   const inkPoints = ann.points.flatMap(([nx, ny]: [number, number]) => {
     const [x, y] = toPdfCoords(nx, ny, pdfW, pdfH, rot);
@@ -121,14 +123,14 @@ function _addInkAnnotation(pdfPage: PDFPage, ann: DrawAnnotation, pdfW: number, 
   const pdfPts = ann.points.map(([nx, ny]: [number, number]) => toPdfCoords(nx, ny, pdfW, pdfH, rot));
   const xs  = pdfPts.map(([x]: [number, number]) => x);
   const ys  = pdfPts.map(([, y]: [number, number]) => y);
-  const pad = ann.thickness;
+  const pad = w;
 
   const annotDict = pdfPage.doc.context.obj({
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Ink'),
     Rect:    [Math.min(...xs) - pad, Math.min(...ys) - pad, Math.max(...xs) + pad, Math.max(...ys) + pad],
     InkList: inkList,
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
+    BS:      pdfPage.doc.context.obj({ W: w }),
     C:       [r, g, b],
     CA:      PDFNumber.of(ann.type === 'freeHighlight' ? 0.4 : 1),
     F:       PDFNumber.of(4),
@@ -188,42 +190,44 @@ function _addFreeTextAnnotation(pdfPage: PDFPage, ann: TextAnnotation, pdfW: num
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addLineAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
+function _addLineAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
-  const pad = ann.thickness;
+  const w   = ann.thickness / scale;
+  const pad = w;
   const annotDict = pdfPage.doc.context.obj({
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Line'),
     Rect:    [Math.min(x1,x2)-pad, Math.min(y1,y2)-pad, Math.max(x1,x2)+pad, Math.max(y1,y2)+pad],
     L:       [x1, y1, x2, y2],
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
+    BS:      pdfPage.doc.context.obj({ W: w }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addArrowAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
+function _addArrowAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
-  const pad = ann.thickness * 5;
+  const w   = ann.thickness / scale;
+  const pad = w * 5;
   const annotDict = pdfPage.doc.context.obj({
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Line'),
     Rect:    [Math.min(x1,x2)-pad, Math.min(y1,y2)-pad, Math.max(x1,x2)+pad, Math.max(y1,y2)+pad],
     L:       [x1, y1, x2, y2],
     LE:      [PDFName.of('None'), PDFName.of('OpenArrow')],
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
+    BS:      pdfPage.doc.context.obj({ W: w }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addSquareAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
+function _addSquareAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
@@ -231,14 +235,14 @@ function _addSquareAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: numb
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Square'),
     Rect:    [Math.min(x1,x2), Math.min(y1,y2), Math.max(x1,x2), Math.max(y1,y2)],
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness / scale }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });
   _appendAnnotation(pdfPage, annotDict);
 }
 
-function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number): void {
+function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: number, pdfH: number, rot: number, scale: number): void {
   const { r, g, b } = hexToRgb01(ann.color);
   const [x1, y1] = toPdfCoords(ann.x1, ann.y1, pdfW, pdfH, rot);
   const [x2, y2] = toPdfCoords(ann.x2, ann.y2, pdfW, pdfH, rot);
@@ -246,7 +250,7 @@ function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: numb
     Type:    PDFName.of('Annot'),
     Subtype: PDFName.of('Circle'),
     Rect:    [Math.min(x1,x2), Math.min(y1,y2), Math.max(x1,x2), Math.max(y1,y2)],
-    BS:      pdfPage.doc.context.obj({ W: ann.thickness }),
+    BS:      pdfPage.doc.context.obj({ W: ann.thickness / scale }),
     C:       [r, g, b],
     F:       PDFNumber.of(4),
   });

--- a/src/renderer/saver.ts
+++ b/src/renderer/saver.ts
@@ -9,7 +9,7 @@ import type { Annotation, DrawAnnotation, HighlightAnnotation, TextAnnotation, S
 import type { PDFViewer } from './viewer.js';
 
 // Cast the direct-path runtime import to the pdf-lib type surface
-const { PDFDocument, PDFName, PDFArray, PDFNumber, PDFString, degrees } =
+const { PDFDocument, PDFName, PDFArray, PDFNumber, PDFString, degrees, rgb, StandardFonts } =
   _pdfLib as unknown as typeof PDFLibNS;
 
 type PDFDoc  = import('pdf-lib').PDFDocument;
@@ -255,13 +255,105 @@ function _addCircleAnnotation(pdfPage: PDFPage, ann: ShapeAnnotation, pdfW: numb
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _appendAnnotation(pdfPage: PDFPage, annotDict: any): void {
-   
+
   const ref    = pdfPage.doc.context.register(annotDict);
   const annots = pdfPage.node.get(PDFName.of('Annots'));
   if (annots instanceof PDFArray) {
     annots.push(ref);
   } else {
-     
+
     pdfPage.node.set(PDFName.of('Annots'), pdfPage.doc.context.obj([ref]));
   }
+}
+
+// ── Footer ───────────────────────────────────────────────────
+
+export interface FooterConfig {
+  left:     string;
+  center:   string;
+  right:    string;
+  fontSize: number;
+}
+
+/**
+ * Draw a 3-column footer on every page and return the modified bytes.
+ * Tokens {page} and {total} are replaced with the current page number and total.
+ */
+export async function embedFooter(pdfBytes: Uint8Array, config: FooterConfig): Promise<Uint8Array> {
+  const pdfDoc = await PDFDocument.load(pdfBytes, { ignoreEncryption: true });
+  const font   = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const total  = pdfDoc.getPageCount();
+  const black  = rgb(0, 0, 0);
+  const margin = 40;
+  const yPos   = 20;
+
+  for (let i = 0; i < total; i++) {
+    const page        = pdfDoc.getPage(i);
+    const { width: pdfW } = page.getSize();
+    const resolve     = (t: string) =>
+      t.replace(/\{page\}/g, String(i + 1)).replace(/\{total\}/g, String(total));
+
+    const l = resolve(config.left);
+    const c = resolve(config.center);
+    const r = resolve(config.right);
+
+    if (l) {
+      page.drawText(l, { x: margin, y: yPos, size: config.fontSize, font, color: black });
+    }
+    if (c) {
+      const tw = font.widthOfTextAtSize(c, config.fontSize);
+      page.drawText(c, { x: (pdfW - tw) / 2, y: yPos, size: config.fontSize, font, color: black });
+    }
+    if (r) {
+      const tw = font.widthOfTextAtSize(r, config.fontSize);
+      page.drawText(r, { x: pdfW - margin - tw, y: yPos, size: config.fontSize, font, color: black });
+    }
+  }
+
+  return pdfDoc.save();
+}
+
+// ── Watermark ────────────────────────────────────────────────
+
+export interface WatermarkConfig {
+  text:     string;
+  fontSize: number;
+  opacity:  number;  // 0.0–1.0
+  angle:    number;  // degrees
+}
+
+/**
+ * Draw a centred, rotated text watermark on every page and return the modified bytes.
+ */
+export async function embedWatermark(pdfBytes: Uint8Array, config: WatermarkConfig): Promise<Uint8Array> {
+  const pdfDoc   = await PDFDocument.load(pdfBytes, { ignoreEncryption: true });
+  const font     = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const grey     = rgb(0.5, 0.5, 0.5);
+  const angleRad = (config.angle * Math.PI) / 180;
+
+  for (let i = 0; i < pdfDoc.getPageCount(); i++) {
+    const page              = pdfDoc.getPage(i);
+    const { width: pdfW, height: pdfH } = page.getSize();
+    const textWidth         = font.widthOfTextAtSize(config.text, config.fontSize);
+
+    // Translate origin so the centre of the text string lands at the page centre
+    const x = pdfW / 2
+      - (textWidth / 2)       * Math.cos(angleRad)
+      + (config.fontSize / 2) * Math.sin(angleRad);
+    const y = pdfH / 2
+      - (textWidth / 2)       * Math.sin(angleRad)
+      - (config.fontSize / 2) * Math.cos(angleRad);
+
+    page.drawText(config.text, {
+      x,
+      y,
+      size:    config.fontSize,
+      font,
+      color:   grey,
+      opacity: config.opacity,
+      rotate:  degrees(config.angle),
+    });
+  }
+
+  return pdfDoc.save();
 }

--- a/src/renderer/saver.ts
+++ b/src/renderer/saver.ts
@@ -339,8 +339,9 @@ export async function embedWatermark(pdfBytes: Uint8Array, config: WatermarkConf
 
     lines.forEach((line, li) => {
       const textWidth  = font.widthOfTextAtSize(line, config.fontSize);
-      // Perpendicular offset (CCW 90° from text direction) to space lines
-      const perpOffset = (li - (lines.length - 1) / 2) * lineHeight;
+      // Perpendicular offset (CCW 90° from text direction) to space lines.
+      // Positive perpOffset moves toward the visual top of the page; line 0 is topmost.
+      const perpOffset = ((lines.length - 1) / 2 - li) * lineHeight;
 
       // Centre each line at page centre then offset perpendicularly
       const x = pdfW / 2

--- a/src/renderer/saver.ts
+++ b/src/renderer/saver.ts
@@ -326,32 +326,41 @@ export interface WatermarkConfig {
  * Draw a centred, rotated text watermark on every page and return the modified bytes.
  */
 export async function embedWatermark(pdfBytes: Uint8Array, config: WatermarkConfig): Promise<Uint8Array> {
-  const pdfDoc   = await PDFDocument.load(pdfBytes, { ignoreEncryption: true });
-  const font     = await pdfDoc.embedFont(StandardFonts.Helvetica);
-  const grey     = rgb(0.5, 0.5, 0.5);
-  const angleRad = (config.angle * Math.PI) / 180;
+  const pdfDoc     = await PDFDocument.load(pdfBytes, { ignoreEncryption: true });
+  const font       = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const grey       = rgb(0.5, 0.5, 0.5);
+  const angleRad   = (config.angle * Math.PI) / 180;
+  const lines      = config.text.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+  const lineHeight = config.fontSize * 1.3;
 
   for (let i = 0; i < pdfDoc.getPageCount(); i++) {
-    const page              = pdfDoc.getPage(i);
+    const page = pdfDoc.getPage(i);
     const { width: pdfW, height: pdfH } = page.getSize();
-    const textWidth         = font.widthOfTextAtSize(config.text, config.fontSize);
 
-    // Translate origin so the centre of the text string lands at the page centre
-    const x = pdfW / 2
-      - (textWidth / 2)       * Math.cos(angleRad)
-      + (config.fontSize / 2) * Math.sin(angleRad);
-    const y = pdfH / 2
-      - (textWidth / 2)       * Math.sin(angleRad)
-      - (config.fontSize / 2) * Math.cos(angleRad);
+    lines.forEach((line, li) => {
+      const textWidth  = font.widthOfTextAtSize(line, config.fontSize);
+      // Perpendicular offset (CCW 90° from text direction) to space lines
+      const perpOffset = (li - (lines.length - 1) / 2) * lineHeight;
 
-    page.drawText(config.text, {
-      x,
-      y,
-      size:    config.fontSize,
-      font,
-      color:   grey,
-      opacity: config.opacity,
-      rotate:  degrees(config.angle),
+      // Centre each line at page centre then offset perpendicularly
+      const x = pdfW / 2
+        - (textWidth / 2)        * Math.cos(angleRad)
+        + (config.fontSize / 2)  * Math.sin(angleRad)
+        - perpOffset             * Math.sin(angleRad);
+      const y = pdfH / 2
+        - (textWidth / 2)        * Math.sin(angleRad)
+        - (config.fontSize / 2)  * Math.cos(angleRad)
+        + perpOffset             * Math.cos(angleRad);
+
+      page.drawText(line, {
+        x,
+        y,
+        size:    config.fontSize,
+        font,
+        color:   grey,
+        opacity: config.opacity,
+        rotate:  degrees(config.angle),
+      });
     });
   }
 

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -89,6 +89,7 @@ export interface Tab {
   _notBeenViewed?: boolean;
   _undoStack?: Array<{ pdfBytes: Uint8Array; annotations: string }>;
   _undoIdx?: number;
+  _undoCleanIdx?: number | null;
 }
 
 // ── CloseContext ──────────────────────────────────────────────

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -87,6 +87,8 @@ export interface Tab {
   _savedBytes?: Uint8Array | null;
   _findCache?: Map<number, FindCacheEntry>;
   _notBeenViewed?: boolean;
+  _undoStack?: Array<{ pdfBytes: Uint8Array; annotations: string }>;
+  _undoIdx?: number;
 }
 
 // ── CloseContext ──────────────────────────────────────────────

--- a/src/renderer/viewer.ts
+++ b/src/renderer/viewer.ts
@@ -455,6 +455,16 @@ export class PDFViewer {
     // PDF.js v4 sizes the text layer via calc(var(--scale-factor) * N px)
     wrapper.style.setProperty('--scale-factor', String(this.scale));
 
+    // Preserve old canvas content before clearing so the browser never shows
+    // a blank canvas between the resize and the render completing.
+    let oldSnapshot: HTMLCanvasElement | null = null;
+    if (canvas.width > 0 && canvas.height > 0) {
+      oldSnapshot = document.createElement('canvas');
+      oldSnapshot.width  = canvas.width;
+      oldSnapshot.height = canvas.height;
+      oldSnapshot.getContext('2d')!.drawImage(canvas, 0, 0);
+    }
+
     canvas.width  = viewport.width;
     canvas.height = viewport.height;
 
@@ -464,6 +474,14 @@ export class PDFViewer {
 
     // Render PDF content
     const ctx = canvas.getContext('2d')!;
+
+    // Draw scaled old content as a placeholder until the real render finishes.
+    // page.render() draws on top and fully replaces it for opaque PDF pages.
+    if (oldSnapshot) {
+      ctx.drawImage(oldSnapshot, 0, 0, viewport.width, viewport.height);
+      oldSnapshot = null;
+    }
+
     await page.render({ canvasContext: ctx, viewport }).promise;
 
     // Render text layer for selection (PDF.js 4.x class-based API)

--- a/src/renderer/viewer.ts
+++ b/src/renderer/viewer.ts
@@ -64,7 +64,7 @@ export class PDFViewer {
     this._annCache         = {}; // pageNum → cached annotation array
     this._pendingRender    = new Set(); // pageNums needing re-render once visible
     this._io               = null;  // IntersectionObserver for deferred renders
-    this._pageSizeCache    = {}; // pageNum → { width, height } in PDF pts — survives sleep
+    this._pageSizeCache    = {}; // pageNum → { width, height } in native (unrotated) PDF pts — survives sleep
     this.isSleeping        = false;
   }
 
@@ -232,12 +232,12 @@ export class PDFViewer {
     return page.getViewport({ scale: this.scale, rotation });
   }
 
-  // Returns { width, height } of the unscaled PDF page in PDF pts (no user rotation).
+  // Returns { width, height } of the unscaled PDF page in native PDF pts (no rotation).
   // Results are cached so this works even while the viewer is sleeping (pdfDoc is null).
   async getPageSize(pageNum: number): Promise<{ width: number; height: number }> {
     if (this._pageSizeCache[pageNum]) return this._pageSizeCache[pageNum];
     const page = await this.pdfDoc!.getPage(pageNum);
-    const vp   = page.getViewport({ scale: 1.0 });
+    const vp   = page.getViewport({ scale: 1.0, rotation: 0 });
     const size = { width: vp.width, height: vp.height };
     this._pageSizeCache[pageNum] = size;
     return size;
@@ -367,9 +367,9 @@ export class PDFViewer {
     const userRot  = this.pageRotations[pageNum] || 0;
     this.pageBaseRotations[pageNum] = page.rotate;
 
-    // Cache unscaled page size so getPageSize() works while sleeping.
+    // Cache unscaled native page size so getPageSize() works while sleeping.
     if (!this._pageSizeCache[pageNum]) {
-      const vp1 = page.getViewport({ scale: 1.0 });
+      const vp1 = page.getViewport({ scale: 1.0, rotation: 0 });
       this._pageSizeCache[pageNum] = { width: vp1.width, height: vp1.height };
     }
 
@@ -416,7 +416,7 @@ export class PDFViewer {
 
     // Populate the page-size cache on every render (cheap: page object is already fetched).
     if (!this._pageSizeCache[pageNum]) {
-      const vp1 = page.getViewport({ scale: 1.0 });
+      const vp1 = page.getViewport({ scale: 1.0, rotation: 0 });
       this._pageSizeCache[pageNum] = { width: vp1.width, height: vp1.height };
     }
 

--- a/src/renderer/viewer.ts
+++ b/src/renderer/viewer.ts
@@ -449,6 +449,10 @@ export class PDFViewer {
       this.pages[idx] = { wrapper, canvas, textDiv, annotCanvas, formLayer, viewportTransform: viewport.transform };
     }
 
+    // Hide the wrapper while the canvas is blank so the browser never paints
+    // a blank hole between the canvas clear and the render completing.
+    wrapper.style.opacity = '0';
+
     // Resize wrapper and canvases to match viewport
     wrapper.style.width  = `${viewport.width}px`;
     wrapper.style.height = `${viewport.height}px`;
@@ -465,6 +469,7 @@ export class PDFViewer {
     // Render PDF content
     const ctx = canvas.getContext('2d')!;
     await page.render({ canvasContext: ctx, viewport }).promise;
+    wrapper.style.opacity = '';
 
     // Render text layer for selection (PDF.js 4.x class-based API)
     // setLayerDimensions() inside TextLayer constructor sets width/height via --scale-factor

--- a/src/renderer/viewer.ts
+++ b/src/renderer/viewer.ts
@@ -455,16 +455,6 @@ export class PDFViewer {
     // PDF.js v4 sizes the text layer via calc(var(--scale-factor) * N px)
     wrapper.style.setProperty('--scale-factor', String(this.scale));
 
-    // Preserve old canvas content before clearing so the browser never shows
-    // a blank canvas between the resize and the render completing.
-    let oldSnapshot: HTMLCanvasElement | null = null;
-    if (canvas.width > 0 && canvas.height > 0) {
-      oldSnapshot = document.createElement('canvas');
-      oldSnapshot.width  = canvas.width;
-      oldSnapshot.height = canvas.height;
-      oldSnapshot.getContext('2d')!.drawImage(canvas, 0, 0);
-    }
-
     canvas.width  = viewport.width;
     canvas.height = viewport.height;
 
@@ -474,14 +464,6 @@ export class PDFViewer {
 
     // Render PDF content
     const ctx = canvas.getContext('2d')!;
-
-    // Draw scaled old content as a placeholder until the real render finishes.
-    // page.render() draws on top and fully replaces it for opaque PDF pages.
-    if (oldSnapshot) {
-      ctx.drawImage(oldSnapshot, 0, 0, viewport.width, viewport.height);
-      oldSnapshot = null;
-    }
-
     await page.render({ canvasContext: ctx, viewport }).promise;
 
     // Render text layer for selection (PDF.js 4.x class-based API)

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -17,6 +17,7 @@ interface Window {
     onCloseTabByFilepath: (callback: (filePath: string) => void) => void;
     copyFileToClipboard: (filePath: string) => Promise<{ ok: boolean }>;
     revealInExplorer:    (filePath: string) => Promise<{ ok: boolean }>;
+    printPdf:            (filePath: string) => Promise<{ ok: boolean; error?: string }>;
     startDrag: (filePath: string) => void;
     setUiZoom: (factor: number) => void;
     getUiZoom: () => number;

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -17,7 +17,9 @@ interface Window {
     onCloseTabByFilepath: (callback: (filePath: string) => void) => void;
     copyFileToClipboard: (filePath: string) => Promise<{ ok: boolean }>;
     revealInExplorer:    (filePath: string) => Promise<{ ok: boolean }>;
-    printPdf:            (filePath: string) => Promise<{ ok: boolean; error?: string }>;
+    openPrintPreview: (filePath: string) => Promise<{ ok: boolean; error?: string }>;
+    onPdfData: (callback: (data: { buffer: ArrayBuffer }) => void) => void;
+    executePrint: (options: { copies: number; color: boolean; scaleFactor: number }) => Promise<{ ok: boolean; error?: string }>;
     startDrag: (filePath: string) => void;
     setUiZoom: (factor: number) => void;
     getUiZoom: () => number;

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -20,13 +20,13 @@ interface Window {
     openPrintPreview:       (filePath: string)                                         => Promise<{ ok: boolean; error?: string }>;
     onPdfData:              (callback: (data: { buffer: ArrayBuffer }) => void)        => void;
     getPrinters:            ()                                                          => Promise<{ name: string; isDefault: boolean }[]>;
-    openPrinterPreferences: (printerName: string)                                      => Promise<{ ok: boolean }>;
+    openPrinterPreferences: (printerName: string)                                      => Promise<{ ok: boolean; error?: string }>;
     executePrint: (options: {
       deviceName:  string;
       copies:      number;
       color:       boolean;
       collate:     boolean;
-      duplexMode:  string;
+      duplexMode:  'simplex' | 'longEdge' | 'shortEdge';
       scaleFactor: number;
       landscape:   boolean;
     }) => Promise<{ ok: boolean; error?: string }>;

--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -17,9 +17,19 @@ interface Window {
     onCloseTabByFilepath: (callback: (filePath: string) => void) => void;
     copyFileToClipboard: (filePath: string) => Promise<{ ok: boolean }>;
     revealInExplorer:    (filePath: string) => Promise<{ ok: boolean }>;
-    openPrintPreview: (filePath: string) => Promise<{ ok: boolean; error?: string }>;
-    onPdfData: (callback: (data: { buffer: ArrayBuffer }) => void) => void;
-    executePrint: (options: { copies: number; color: boolean; scaleFactor: number }) => Promise<{ ok: boolean; error?: string }>;
+    openPrintPreview:       (filePath: string)                                         => Promise<{ ok: boolean; error?: string }>;
+    onPdfData:              (callback: (data: { buffer: ArrayBuffer }) => void)        => void;
+    getPrinters:            ()                                                          => Promise<{ name: string; isDefault: boolean }[]>;
+    openPrinterPreferences: (printerName: string)                                      => Promise<{ ok: boolean }>;
+    executePrint: (options: {
+      deviceName:  string;
+      copies:      number;
+      color:       boolean;
+      collate:     boolean;
+      duplexMode:  string;
+      scaleFactor: number;
+      landscape:   boolean;
+    }) => Promise<{ ok: boolean; error?: string }>;
     startDrag: (filePath: string) => void;
     setUiZoom: (factor: number) => void;
     getUiZoom: () => number;


### PR DESCRIPTION
## Summary

- **Print preview** — replaces the broken `window.print()` / `webContents.print()` approach with a dedicated preview window that renders pages via PDF.js → PNG (canvas elements don't print reliably in Chromium; `<img>` elements do). Includes printer selection, copies, collate, page range, scale, colour/greyscale, duplex, pages-per-sheet, booklet mode, orientation toggle with letterbox preview, and Ctrl+scroll zoom in the preview window.
- **Prompt to save before printing** — if the document has unsaved annotations the user is asked to save first, preventing stale output.
- **Zoom to cursor** — Ctrl+scroll now keeps the content point under the cursor fixed (CSS `transformOrigin` preview → corrected scroll offset after debounce). Fixes the blank-flash and page-1 jump that occurred when zooming from later pages.
- **Annotation fixes on rotated pages** — corrected `_pageSizeCache` to store unrotated native dimensions (`rotation: 0`), fixed swapped `rot=90`/`rot=270` cases in `toPdfCoords`, and added `rotateAnnotations()` to transform stored coordinates when the user rotates a page.
- **Annotation thickness fixes** — thickness is now normalised to PDF points at storage time (÷ `viewer.scale`) and multiplied back when rendering to canvas pixels, so strokes stay visually consistent across zoom levels and don't compound on save/reopen.
- **Extension ID dialog** — moved the input/textarea guard earlier in the global keydown handler so Ctrl+C/V/X/Z/Y work inside the dialog. Added a right-click Cut/Copy/Paste context menu matching the existing style.

## Test plan

- [ ] Open a PDF, annotate, rotate a page, save and reopen — annotations should appear in the correct positions
- [ ] Draw annotations at various zoom levels — stroke width should look the same at 50%, 100%, and 200%
- [ ] Ctrl+scroll to zoom — the point under the cursor should stay fixed; no blank flash or jump to page 1
- [ ] File → Print — print preview opens with correct page count and layout
- [ ] Try all print options: page range, copies, collate, duplex, pages-per-sheet, booklet, orientation, greyscale
- [ ] Print a landscape PDF — should fill the page rather than scaling down on portrait paper
- [ ] Print with unsaved annotations — should prompt to save first
- [ ] Open Extension ID dialog, paste with Ctrl+V and right-click → Paste — both should work