### PR TITLE
Warn user when pages fail to render in print preview

### DIFF
--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -74,6 +74,7 @@ interface PageData {
   naturalH: number;      // 1× CSS height
 }
 const pageData: PageData[] = []; // index 0 = page 1
+const failedPages: number[] = []; // 1-based page numbers that failed to render as PNG
 
 // ── Printers ──────────────────────────────────────────────────
 (async () => {
@@ -305,6 +306,12 @@ btnPrint.addEventListener('click', async () => {
   const duplexMode  = selDuplex.value as 'simplex' | 'longEdge' | 'shortEdge';
   const landscape   = chkBooklet.checked || printOrientation === 'landscape';
 
+  if (failedPages.length > 0) {
+    const n = failedPages.length;
+    const ok = confirm(`${n} page${n === 1 ? '' : 's'} (${failedPages.join(', ')}) failed to render and will print blank. Continue anyway?`);
+    if (!ok) return;
+  }
+
   btnPrint.disabled = true;
   statusEl.textContent = 'Printing…';
   try {
@@ -357,7 +364,7 @@ window.api.onPdfData(async ({ buffer }) => {
       const img      = new Image();
       await new Promise<void>(resolve => {
         img.onload  = () => resolve();
-        img.onerror = () => resolve(); // silently skip bad frames
+        img.onerror = () => { failedPages.push(pageNum); resolve(); };
         img.src = dataUrl;
       });
 
@@ -373,7 +380,11 @@ window.api.onPdfData(async ({ buffer }) => {
     return;
   }
 
-  statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;
+  if (failedPages.length > 0) {
+    statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'} — warning: ${failedPages.length} page${failedPages.length === 1 ? '' : 's'} failed to render (pages ${failedPages.join(', ')}) and will print blank`;
+  } else {
+    statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;
+  }
   fitToWidth();
   renderPreview();
 });


### PR DESCRIPTION
## Summary

- Tracks failed page numbers (1-based) in a module-level `failedPages` array instead of silently discarding the `img.onerror` event
- After rendering completes, the status bar shows which page numbers failed and that they will print blank
- When the user clicks Print and any pages failed, a confirmation dialog is shown before proceeding so blank pages are not sent to the printer without the user's knowledge

## Test plan

- [ ] Normal rendering with a valid PDF — no warning should appear
- [ ] If a page fails to render (e.g. corrupt canvas), the status bar should list the failed page numbers
- [ ] Clicking Print with failed pages shows a confirmation dialog; cancelling aborts the print job