### PR TITLE
Discard stale zoom cursor when tab changes during debounce

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -33,6 +33,7 @@ const _closedTabStack: { filePath: string }[] = [];
 let _zoomTimer: ReturnType<typeof setTimeout> | null = null; // setTimeout handle for deferred re-render
 let _zoomTarget: number | null = null; // accumulated target scale while debounce is pending
 let _zoomCursor: { x: number; y: number } | null = null; // cursor pane-relative coords at zoom start
+let _zoomTabId:  number | null = null;  // ID of the tab that started the current zoom gesture
 
 // Custom scrollbar drag state
 let _sbDragging        = false;
@@ -1224,6 +1225,7 @@ function zoom(delta: number, cursorX?: number, cursorY?: number) {
         x: Math.max(0, Math.min(pane.clientWidth,  cursorX - paneRect.left)),
         y: Math.max(0, Math.min(pane.clientHeight, cursorY - paneRect.top)),
       };
+      _zoomTabId = activeTab.id;
     }
 
     if (_zoomCursor !== null) {
@@ -1259,8 +1261,10 @@ async function _applyZoomNow(scale: number) {
   const v        = activeTab.viewer;
   const pane     = activeTab.pane;
   const oldScale = v.scale;
-  const cursor   = _zoomCursor;
+  // Discard stale cursor if the user switched tabs during the debounce.
+  const cursor   = (activeTab.id === _zoomTabId) ? _zoomCursor : null;
   _zoomCursor    = null;
+  _zoomTabId     = null;
 
   // Capture scroll snapshot before the CSS transform is removed so the
   // pre-scroll and final-scroll calculations both use the committed position.


### PR DESCRIPTION
## Summary

- `_zoomCursor` was module-level with no record of which tab started the zoom gesture
- If the user switched tabs during the 250 ms debounce, `_applyZoomNow` would fire on the new active tab using cursor coordinates captured from the old tab's pane, scrolling to the wrong position
- Add `_zoomTabId` to record which tab started the gesture; `_applyZoomNow` discards the cursor and falls back to `top center` if the active tab has changed by the time the debounce fires

## Test plan

- [ ] Ctrl+scroll to zoom on Tab A, immediately switch to Tab B before the debounce fires — Tab B should render at top-center, not jump to a position derived from Tab A's cursor coordinates
- [ ] Normal Ctrl+scroll zoom on a single tab still keeps the content point under the cursor fixed