### PR TITLE
Handle clipboard access denial in context menu paste

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1742,7 +1742,7 @@ inputCtxMenu.addEventListener('mousedown', (e) => {
     case 'paste':
       navigator.clipboard.readText().then(text => {
         input.setRangeText(text, input.selectionStart ?? 0, input.selectionEnd ?? 0, 'end');
-      });
+      }).catch(() => { /* clipboard access denied — nothing to paste */ });
       break;
   }
 });


### PR DESCRIPTION
## Summary

- `navigator.clipboard.readText()` was missing a `.catch()`, so a clipboard permission denial would produce an unhandled promise rejection with no feedback to the user
- Added `.catch(() => {})` to silently swallow the denial — there is nothing useful to paste if access is denied

## Test plan

- [ ] Right-click → Paste in the Extension ID dialog with clipboard permission granted — paste works
- [ ] Deny clipboard permission in DevTools → right-click → Paste — no unhandled rejection in the console, paste silently no-ops