### PR TITLE
Clean up modal keydown listener even if dialog is forcibly removed

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1042,17 +1042,26 @@ function showDialog(options: {
     const footer = document.createElement('div');
     footer.className = 'modal-footer';
 
+    const controller = new AbortController();
+
     const dismiss = (idx: number) => {
-      document.removeEventListener('keydown', onKey);
-      document.body.removeChild(overlay);
+      controller.abort(); // removes the keydown listener
+      overlay.remove();
       resolve(idx);
     };
+
+    // Also clean up if the overlay is removed from the DOM by any other means
+    // (e.g. another piece of code clearing the body or closing the panel).
+    const observer = new MutationObserver(() => {
+      if (!overlay.isConnected) { controller.abort(); observer.disconnect(); resolve(cancelId); }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
 
     options.buttons.forEach((label, i) => {
       const btn = document.createElement('button');
       btn.className = 'modal-btn' + (i === defaultId ? ' primary' : '');
       btn.textContent = label;
-      btn.addEventListener('click', () => dismiss(i));
+      btn.addEventListener('click', () => { observer.disconnect(); dismiss(i); });
       footer.appendChild(btn);
     });
 
@@ -1060,8 +1069,8 @@ function showDialog(options: {
     overlay.appendChild(box);
     document.body.appendChild(overlay);
 
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') dismiss(cancelId); };
-    document.addEventListener('keydown', onKey);
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') { observer.disconnect(); dismiss(cancelId); } };
+    document.addEventListener('keydown', onKey, { signal: controller.signal });
   });
 }
 


### PR DESCRIPTION
## Summary

- `showDialog` added a `keydown` listener and only removed it inside `dismiss()`. If the overlay was removed from the DOM by any other means the listener would leak.
- Switch to `AbortController` with `{ signal: controller.signal }` for automatic listener removal when `controller.abort()` is called
- Add a `MutationObserver` that watches `document.body` for the overlay being disconnected; if it is removed externally the observer resolves the promise as a cancel and disconnects itself
- Button click handlers and the Escape handler both disconnect the observer before calling `dismiss` to avoid the observer racing with the explicit path

## Test plan

- [ ] Normal dialog usage (click button / press Escape) still works
- [ ] If the overlay is programmatically removed from the DOM the keydown listener is cleaned up and the promise resolves with cancelId