### PR TITLE
Warn on unhandled annotation type in rotateAnnotations

### DIFF
--- a/src/renderer/annotator.ts
+++ b/src/renderer/annotator.ts
@@ -138,6 +138,11 @@ export class Annotator {
           const { x1, y1, x2, y2 } = ann;
           ann.x1 = 1 - y1; ann.y1 = x1;
           ann.x2 = 1 - y2; ann.y2 = x2;
+        } else {
+          // Runtime guard: if a new Annotation type is added without a
+          // corresponding branch here, warn rather than silently skip rotation
+          // and leave coordinates in an inconsistent state.
+          console.warn('rotateAnnotations: unhandled annotation type:', (ann as { type: unknown }).type);
         }
       }
     }


### PR DESCRIPTION
## Summary

- `rotateAnnotations` had an exhaustive `if/else if` chain with no `else` clause; any future annotation type added to the union without a corresponding branch would silently skip rotation, leaving coordinates in an inconsistent state with no error
- Add an `else` clause that logs `console.warn` so the omission surfaces immediately during development
- A compile-time `never` assignment was attempted but TypeScript cannot narrow compound `||` conditions on multi-value union discriminants, so the runtime guard is the practical alternative

## Test plan

- [ ] Rotate a page with existing annotation types — no warning logged, rotation works
- [ ] No regressions