### PR TITLE
Give each downloadPdfToTemp temp file a unique name

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -428,14 +428,17 @@ function downloadPdfToTemp(url: string, redirectsLeft = 5): Promise<string> {
         return;
       }
 
-      let fileName: string;
+      let baseName: string;
       try {
         const base = path.basename(new URL(url).pathname) || 'download';
-        fileName = base.toLowerCase().endsWith('.pdf') ? base : `${base}.pdf`;
+        baseName = base.toLowerCase().endsWith('.pdf') ? base : `${base}.pdf`;
       } catch {
-        fileName = 'download.pdf';
+        baseName = 'download.pdf';
       }
-      const filePath = path.join(tempDir, fileName);
+      // Prefix with a random token to prevent concurrent downloads of the same
+      // URL from racing to write the same temp file.
+      const token    = Math.random().toString(36).slice(2, 10);
+      const filePath = path.join(tempDir, `${token}-${baseName}`);
       const fileStream = fs.createWriteStream(filePath);
       res.pipe(fileStream);
       fileStream.on('finish', () => {


### PR DESCRIPTION
## Summary

- Two concurrent downloads of the same URL both derived the same filename from the URL basename and would race to write the same temp file path, with both write streams potentially corrupting each other's data
- Prefix each temp filename with a random 8-character token so each download invocation gets a distinct path, eliminating the write-stream collision

## Test plan

- [ ] Download a remote PDF — still opens correctly
- [ ] Two concurrent downloads of the same URL each produce a separate temp file