### PR TITLE
Tighten window.d.ts types for print IPC methods

### DIFF
--- a/src/renderer/window.d.ts
+++ b/src/renderer/window.d.ts
@@ -20,13 +20,13 @@ interface Window {
     openPrintPreview:       (filePath: string)                                         => Promise<{ ok: boolean; error?: string }>;
     onPdfData:              (callback: (data: { buffer: ArrayBuffer }) => void)        => void;
     getPrinters:            ()                                                          => Promise<{ name: string; isDefault: boolean }[]>;
-    openPrinterPreferences: (printerName: string)                                      => Promise<{ ok: boolean }>;
+    openPrinterPreferences: (printerName: string)                                      => Promise<{ ok: boolean; error?: string }>;
     executePrint: (options: {
       deviceName:  string;
       copies:      number;
       color:       boolean;
       collate:     boolean;
-      duplexMode:  string;
+      duplexMode:  'simplex' | 'longEdge' | 'shortEdge';
       scaleFactor: number;
       landscape:   boolean;
     }) => Promise<{ ok: boolean; error?: string }>;


### PR DESCRIPTION
## Summary

- `openPrinterPreferences` was typed as `Promise<{ ok: boolean }>` but the handler now returns `{ ok: boolean; error?: string }` (since the execFile fix added error surfacing) — add `error?`
- `duplexMode` in `executePrint` was typed as `string` in the declaration but as `'simplex' | 'longEdge' | 'shortEdge'` in preload.ts and the main handler — narrow to the union literal to match

## Test plan

- [ ] TypeScript build passes with no new errors