### PR TITLE
Fix release regressions: print preview, dev tools, silent failures

### DIFF
--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -131,7 +131,7 @@ details[open] summary { margin-bottom: 8px; }
 
 /* ── Print output ─────────────────────────────────────────────── */
 @media print {
-  @page { margin: 0; size: auto; }
+  @page { margin: 0; }
   #settings-panel { display: none !important; }
   #preview-toolbar { display: none !important; }
   body { display: block; overflow: visible; }

--- a/assets/print-preview.css
+++ b/assets/print-preview.css
@@ -137,13 +137,14 @@ details[open] summary { margin-bottom: 8px; }
   body { display: block; overflow: visible; }
   #preview-wrapper { display: block; overflow: visible; }
   #preview-area { padding: 0; gap: 0; background: white; overflow: visible; display: block; zoom: normal; }
-  /* Each page wrapper fills exactly one sheet of paper */
+  /* Each page wrapper fills exactly one sheet of paper.
+     !important is required to beat the inline style.width/height set by JS. */
   .print-page {
     box-shadow: none;
     page-break-after: always;
     break-after: page;
-    width: 100vw;
-    height: 100vh;
+    width: 100vw !important;
+    height: 100vh !important;
     overflow: hidden;
     display: flex;
     align-items: center;

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     },
     "files": [
       "out/**/*",
-      "renderer/index.html",
+      "renderer/**/*",
       "assets/**/*",
       "node_modules/**/*"
     ]

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "reamlet",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Lightweight standalone PDF viewer for Windows",
   "main": "out/main.js",
   "packageManager": "pnpm@10.32.1",
+  "author": "Nick Hespe",
   "scripts": {
     "clean": "node -e \"['out','dist','native-host/dist'].forEach(d => require('fs').rmSync(d, { recursive: true, force: true }))\"",
     "build": "tsc -p tsconfig.main.json && tsc -p tsconfig.renderer.json",

--- a/src/main.ts
+++ b/src/main.ts
@@ -205,7 +205,6 @@ ipcMain.handle('notify-tab-transferred', (_event: IpcMainInvokeEvent, sourceWind
 });
 
 ipcMain.on('open-devtools', (event: IpcMainEvent) => {
-  if (app.isPackaged) return;
   BrowserWindow.fromWebContents(event.sender)?.webContents.toggleDevTools();
 });
 
@@ -263,13 +262,16 @@ ipcMain.handle('open-print-preview', async (_event: IpcMainInvokeEvent, filePath
     },
   });
 
-  await previewWin.loadFile(path.join(__dirname, '..', 'renderer', 'print-preview.html'));
-  previewWin.show();
-
-  const buffer = fs.readFileSync(filePath);
-  previewWin.webContents.send('pdf-data', { buffer: buffer.buffer });
-
-  return { ok: true };
+  try {
+    await previewWin.loadFile(path.join(__dirname, '..', 'renderer', 'print-preview.html'));
+    previewWin.show();
+    const buffer = fs.readFileSync(filePath);
+    previewWin.webContents.send('pdf-data', { buffer: buffer.buffer });
+    return { ok: true };
+  } catch (err) {
+    previewWin.destroy();
+    return { ok: false, error: (err as Error).message };
+  }
 });
 
 // Execute a silent print (no system dialog) from the preview window's renderer process.
@@ -469,7 +471,19 @@ function downloadPdfToTemp(url: string, redirectsLeft = 5): Promise<string> {
 // Resolve a target (URL or local path) to a local file path ready for opening.
 async function resolveTarget(target: string): Promise<string | null> {
   if (isHttpUrl(target)) {
-    try { return await downloadPdfToTemp(target); } catch { return null; }
+    try {
+      const filePath = await downloadPdfToTemp(target);
+      dialog.showMessageBox({
+        type:    'info',
+        title:   'Reamlet — Download complete',
+        message: `Downloaded to:\n${filePath}`,
+        buttons: ['OK'],
+      });
+      return filePath;
+    } catch (err) {
+      dialog.showErrorBox('Reamlet — Could not open URL', (err as Error).message ?? 'Download failed.');
+      return null;
+    }
   }
   return target;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -311,6 +311,30 @@ function getManifestPath(): string {
   return path.join(path.dirname(process.execPath), 'com.reamlet.chromebridge.json');
 }
 
+// Persist user settings (e.g. extensionId) in userData so they survive reinstalls.
+function getUserDataSettingsPath(): string {
+  return path.join(app.getPath('userData'), 'settings.json');
+}
+function readUserDataSettings(): Record<string, unknown> {
+  try { return JSON.parse(fs.readFileSync(getUserDataSettingsPath(), 'utf8')); } catch { return {}; }
+}
+function writeUserDataSettings(settings: Record<string, unknown>): void {
+  fs.writeFileSync(getUserDataSettingsPath(), JSON.stringify(settings, null, 2) + '\n', 'utf8');
+}
+
+// Apply a saved extension ID to the manifest. Called on startup so reinstalls don't wipe the ID.
+function restoreExtensionIdToManifest(): void {
+  const settings = readUserDataSettings();
+  const id = settings.extensionId;
+  if (typeof id !== 'string' || !id) return;
+  try {
+    const p = getManifestPath();
+    const manifest = JSON.parse(fs.readFileSync(p, 'utf8'));
+    manifest.allowed_origins = [`chrome-extension://${id}/`];
+    fs.writeFileSync(p, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+  } catch { /* manifest unwritable — ignore */ }
+}
+
 ipcMain.handle('get-extension-id', () => {
   try {
     const manifest = JSON.parse(fs.readFileSync(getManifestPath(), 'utf8'));
@@ -331,6 +355,9 @@ ipcMain.handle('set-extension-id', (_event: IpcMainInvokeEvent, id: string) => {
     const manifest = JSON.parse(fs.readFileSync(p, 'utf8'));
     manifest.allowed_origins = [`chrome-extension://${id}/`];
     fs.writeFileSync(p, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+    const settings = readUserDataSettings();
+    settings.extensionId = id;
+    writeUserDataSettings(settings);
     return { ok: true };
   } catch (err) {
     return { ok: false, error: (err as Error).message };
@@ -518,6 +545,7 @@ if (!gotLock) {
   });
 
   app.whenReady().then(async () => {
+    restoreExtensionIdToManifest();
     const pendingTarget = _pendingOpenFile || getArgvTarget(process.argv);
     _pendingOpenFile = null;
     const openPath   = pendingTarget ? await resolveTarget(pendingTarget) : null;

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1324,7 +1324,7 @@ async function fitWidth() {
   const v    = activeTab.viewer;
   const vp   = await v.getViewport(1);
   const tocW = tocPanel.classList.contains('hidden') ? 0 : tocPanel.offsetWidth;
-  const gap  = Math.round(screen.width * 0.02);
+  const gap  = Math.round(screen.width * 0.01);
   const availableW = activeTab.pane.clientWidth - sidebar.offsetWidth - tocW - 2 * gap;
   await _applyZoomNow(Math.round((availableW / (vp.width / v.scale)) * 100) / 100);
 }

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1094,7 +1094,14 @@ async function printTab(tab: Tab | null) {
     await saveTab(tab);
     if (tab.dirty) return; // save was cancelled or failed
   }
-  await window.api.openPrintPreview(tab.filePath);
+  try {
+    const result = await window.api.openPrintPreview(tab.filePath);
+    if (!result.ok) {
+      await showDialog({ title: 'Print Error', message: result.error ?? 'Could not open print preview.', buttons: ['OK'], defaultId: 0, cancelId: 0 });
+    }
+  } catch (err) {
+    await showDialog({ title: 'Print Error', message: (err as Error).message ?? 'Could not open print preview.', buttons: ['OK'], defaultId: 0, cancelId: 0 });
+  }
 }
 
 async function reopenLastTab() {

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1321,12 +1321,12 @@ async function _applyZoomNow(scale: number) {
 
 async function fitWidth() {
   if (!activeTab) return;
-  const v  = activeTab.viewer;
-  const vp = await v.getViewport(1);
-  const tocW       = tocPanel.classList.contains('hidden') ? 0 : tocPanel.offsetWidth;
-  const sbRight    = tocW + SCROLLBAR_GAP + 10; // scrollbar sits left of toc (10px wide) with gap
-  const availableW = activeTab.pane.clientWidth - 2 * Math.max(sidebar.offsetWidth, sbRight);
-  await _applyZoomNow(Math.round(((availableW - 32) / (vp.width / v.scale)) * 100) / 100);
+  const v    = activeTab.viewer;
+  const vp   = await v.getViewport(1);
+  const tocW = tocPanel.classList.contains('hidden') ? 0 : tocPanel.offsetWidth;
+  const gap  = Math.round(screen.width * 0.02);
+  const availableW = activeTab.pane.clientWidth - sidebar.offsetWidth - tocW - 2 * gap;
+  await _applyZoomNow(Math.round((availableW / (vp.width / v.scale)) * 100) / 100);
 }
 
 async function fitHeight() {

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -411,6 +411,12 @@ window.api.onPdfData(async ({ buffer }) => {
   } else {
     statusEl.textContent = `${totalPages} page${totalPages === 1 ? '' : 's'}`;
   }
+  // Default to landscape orientation if the first page is wider than tall
+  if (pageData.length > 0 && pageData[0].naturalW > pageData[0].naturalH) {
+    printOrientation = 'landscape';
+    (document.querySelector('input[name="orientation"][value="landscape"]') as HTMLInputElement).checked = true;
+  }
   fitToWidth();
   renderPreview();
+  btnPrint.focus();
 });

--- a/src/renderer/print-preview.ts
+++ b/src/renderer/print-preview.ts
@@ -338,6 +338,17 @@ btnPrint.addEventListener('click', async () => {
     if (!ok) return;
   }
 
+  // Set @page orientation so 100vw/100vh resolve to the correct paper dimensions.
+  // Without this, Chromium uses the default portrait @page size and Electron's
+  // landscape:true just rotates the output, causing landscape pages to print at ~71%.
+  let pageStyle = document.getElementById('reamlet-page-orientation') as HTMLStyleElement | null;
+  if (!pageStyle) {
+    pageStyle = document.createElement('style');
+    pageStyle.id = 'reamlet-page-orientation';
+    document.head.appendChild(pageStyle);
+  }
+  pageStyle.textContent = `@page { size: ${landscape ? 'landscape' : 'portrait'}; margin: 0; }`;
+
   btnPrint.disabled = true;
   statusEl.textContent = 'Printing…';
   try {


### PR DESCRIPTION
## Summary

- **Print does nothing (packaged build):** `renderer/print-preview.html` was excluded from the packaged ASAR because `package.json` listed only `renderer/index.html`. Changed to `renderer/**/*` so all renderer HTML files are included.
- **Dev tools button blocked in packaged build:** The `open-devtools` IPC handler had an `if (app.isPackaged) return;` guard added in PR #55, silently discarding the custom titlebar's dev tools invocation. Guard removed.
- **Silent print failure:** `open-print-preview` had no error handling — if `loadFile` threw, a hidden `BrowserWindow` leaked into `getAllWindows()`. Wrapped in try-catch; destroys the preview window and returns `{ ok: false, error }` on failure. `printTab` in `app.ts` now checks `result.ok` and shows an error dialog.
- **Silent URL download failure:** `resolveTarget` caught all `downloadPdfToTemp` rejections and returned `null` with no user feedback. Now shows a `dialog.showMessageBox` with the downloaded file path on success (for debugging) and a `dialog.showErrorBox` on failure.
- **Extension ID wiped on reinstall (#71):** Extension ID is now saved to `userData/settings.json` when set and restored to the native messaging manifest on startup, so NSIS reinstalls that overwrite the manifest with placeholder values no longer lose the user's configuration.
- **Print orientation and focus (#72):** Print preview now defaults to landscape orientation when the first page is wider than tall. The Print button is focused after render so Ctrl+P → Enter prints without requiring a mouse click.
